### PR TITLE
Add master plan for UE5 plugin migration

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,73 @@
+# Majestik World Master Plan
+
+## Purpose & Scope
+This master plan establishes the end-to-end roadmap for transforming the existing Majestik World (Veloren fork) workspace into a drop-in Unreal Engine 5.6+ plugin while preserving and extending our Rust-based gameplay foundation. It aligns engineering, content, and operations teams around shared milestones, defines guardrails for cross-language integration, and identifies the documentation and CI updates required once the base plan solidifies.
+
+## Strategic Objectives
+1. **Deliver a UE 5.6+ plugin** that exposes Majestik World's Rust gameplay, networking, and world simulation through Epic-sanctioned extension points.
+2. **Retain deterministic Rust systems** for non-UE-facing logic, exposing them via safe FFI bridges that follow Unreal plugin standards.
+3. **Modernize assets and pipelines** (Nanite, Control Rig, MetaSound, UE localization) while preserving existing data tables, save formats, and player progression.
+4. **Institutionalize CI/CD coverage** for both Rust and Unreal build targets, ensuring plugin packaging, ABI validation, and content cooking are reproducible.
+5. **Document and govern the migration** by updating SPECS.md, README.md, and AGENTS.md once the foundational architecture is validated.
+
+## Guiding Principles
+- **Spec-first execution**: Reference SPECS.md, the existing `plan.md`, and future UE migration specs for every change.
+- **Rust core as source of truth**: Simulation, world generation, and data registries remain Rust-driven and are exposed to UE via narrow, testable interfaces.
+- **UE-native presentation layer**: Rendering, input, audio, UI, and networking surfaces use Unreal frameworks (Nanite, Enhanced Input, AudioMixer, replication).
+- **Additive, testable integration**: Introduce abstraction traits and FFI surfaces incrementally; preserve current gameplay determinism during each phase.
+- **CI as contract**: Expand automated checks in lockstep with new build surfaces, preventing regressions across Rust crates and UE modules.
+
+## Phased Roadmap
+### Phase 0 — Foundation & Governance
+- Ratify this PLAN.md with stakeholders; designate owners for gameplay, UE integration, assets, and CI.
+- Freeze non-critical feature work in `voxygen` and other engine-facing crates while planning the migration.
+- Stand up a `ue5-migration` branch for documentation, prototypes, and tooling experiments that should not block ongoing Rust improvements.
+
+### Phase 1 — Core Extraction & Abstraction
+- Audit Rust crates (common, world, server, network) to eliminate direct dependencies on winit, wgpu, cpal, and platform APIs by introducing trait-based ports.
+- Consolidate reusable gameplay and simulation crates into a dedicated `rust/core` workspace compiled as static libraries with `panic=abort`.
+- Define serialization contracts for state snapshots, world chunks, player data, and asset tables, ensuring compatibility with Unreal data structures.
+
+### Phase 2 — FFI & Plugin Skeleton
+- Design the C ABI surface (init, tick, shutdown, event queues, data queries) and generate headers via `cbindgen` or UniFFI.
+- Scaffold the UE plugin directory (`Plugins/MajestikWorld/`) with module classes, build rules (`MajestikWorld.Build.cs`), and stub subsystems (GameInstance, Actor Components).
+- Prototype bidirectional messaging: UE input events converted to Rust-friendly structs; Rust event bundles consumed by UE gameplay actors.
+
+### Phase 3 — System Integration
+- **Networking**: Replace the QUIC transport with UE NetDriver replication, calling Rust diff/compression helpers from replication callbacks.
+- **Rendering & Animation**: Translate voxel/mesh data into Nanite-ready assets; drive skeletal animation via Control Rig using Rust state IDs.
+- **Audio & UI**: Map Rust semantic audio cues to MetaSound graphs; rebuild inventories, quests, and chat with UMG/Slate widgets reading Rust data snapshots.
+- **Tooling**: Create UE Editor utilities for importing Veloren assets, verifying localization, and registering data tables.
+
+### Phase 4 — Asset & Data Pipeline Modernization
+- Batch-convert existing models, terrain, and particle effects to Nanite and Niagara formats while retaining original collision/physics metadata for Rust.
+- Align localization (`common/i18n`) with UE Localization Dashboard exports; ensure save-game compatibility through validation suites.
+- Establish automated asset cooking and packaging workflows compatible with Epic’s distribution requirements.
+
+### Phase 5 — QA, CI, and Documentation Lockdown
+- Expand GitHub Actions to run `cargo fmt`, `cargo clippy --all-targets`, `cargo test --all`, Unreal `RunUAT BuildPlugin`, ABI regression tests (`ctest`), and asset validation scripts.
+- Author integration and gameplay regression tests that tick the Rust simulation through UE harnesses, verifying determinism and replication stability.
+- Update SPECS.md, README.md, and AGENTS.md with finalized architecture, coding standards, and contributor workflows for the UE plugin era.
+- Define release criteria, packaging steps, and a rolling schedule for hotfixes and content updates post-migration.
+
+## Cross-Cutting Workstreams
+- **Security & Compliance**: Review third-party crates and UE modules for licensing; ensure Epic Marketplace submission policies are met.
+- **Performance Engineering**: Carry forward existing performance plan (`plan.md`) insights into UE (profiling hooks, GPU/CPU telemetry, scalability tiers).
+- **Developer Experience**: Provide reproducible Nix/flake or containerized toolchains for building Rust libraries and UE plugins locally.
+- **Community & Documentation**: Prepare contributor guides covering how to extend Rust systems, add UE assets, and test cross-language features.
+
+## Deliverables & Exit Criteria
+- ✅ Rust core libraries compiled as platform-ready artifacts and consumable via generated C headers.
+- ✅ UE plugin skeleton linking against Rust, demonstrating input → simulation → replication → presentation loop.
+- ✅ Automated CI pipeline covering Rust checks, Unreal builds, ABI validation, and asset packaging.
+- ✅ Migration guides for assets, networking, and gameplay systems, with documentation updates approved.
+- ✅ Sign-off from gameplay, engine, and operations leads confirming readiness for UE-centric development.
+
+## Next Immediate Actions
+1. Circulate PLAN.md and `docs/ue5_plugin_migration_plan.md` for stakeholder review; assign owners per phase/workstream.
+2. Kick off dependency abstraction spikes to decouple Rust gameplay crates from winit/wgpu/cpal.
+3. Prototype the Rust static library build + `cbindgen` header generation to validate integration assumptions.
+4. Draft updates for SPECS.md/README.md/AGENTS.md outlining forthcoming workflow changes once prototypes succeed.
+
+---
+*This master plan will be revisited after Phase 2 prototypes validate the Rust ⇄ UE integration strategy, at which point documentation updates and downstream tasks will be scheduled.*

--- a/UE5_PLUGIN_MASTER_PLAN.md
+++ b/UE5_PLUGIN_MASTER_PLAN.md
@@ -11,14 +11,16 @@ This master plan establishes the end-to-end roadmap for transforming the existin
 5. **Document and govern the migration** by updating SPECS.md, README.md, and AGENTS.md once the foundational architecture is validated.
 
 ## Guiding Principles
-- **Spec-first execution**: Reference SPECS.md, the existing `plan.md`, and future UE migration specs for every change.
+- **Spec-first execution**: Reference SPECS.md and future UE migration specs for every change. This plan supersedes the rendering-related sections of the existing `plan.md` while preserving its performance engineering insights for UE integration.
 - **Rust core as source of truth**: Simulation, world generation, and data registries remain Rust-driven and are exposed to UE via narrow, testable interfaces.
 - **UE-native presentation layer**: Rendering, input, audio, UI, and networking surfaces use Unreal frameworks (Nanite, Enhanced Input, AudioMixer, replication).
 - **Additive, testable integration**: Introduce abstraction traits and FFI surfaces incrementally; preserve current gameplay determinism during each phase.
 - **CI as contract**: Expand automated checks in lockstep with new build surfaces, preventing regressions across Rust crates and UE modules.
 
 ## Phased Roadmap
+*Note: This master plan provides the strategic overview. For detailed technical implementation, see [UE5 Plugin Migration Technical Plan](docs/ue5_plugin_migration_plan.md) which contains 7 detailed phases that implement the 6 strategic phases outlined below.*
 ### Phase 0 — Foundation & Governance
+- **GPL-3.0 Legal Review (CRITICAL)**: Conduct comprehensive GPL-3.0 compatibility analysis for UE plugin distribution, as copyleft requirements may fundamentally impact architecture decisions and Epic Marketplace eligibility; document findings and approvals before Phase 1 begins.
 - Ratify this UE5 Plugin Master Plan with stakeholders; designate owners for gameplay, UE integration, assets, and CI.
 - Freeze non-critical feature work in `voxygen` and other engine-facing crates while planning the migration.
 - Stand up a `ue5-migration` branch for documentation, prototypes, and tooling experiments that should not block ongoing Rust improvements.
@@ -29,7 +31,7 @@ This master plan establishes the end-to-end roadmap for transforming the existin
 - **Phase 1b – Rendering/data surface extraction (≈3 engineer-weeks)**: Isolate `wgpu` dependencies behind feature-gated adapters, consolidate gameplay and simulation crates into a `rust/core` workspace compiled as static libraries with `panic=abort`, and document all render-time data contracts.
 - **Phase 1c – Audio & platform shims (≈1 engineer-week)**: Replace `cpal`/platform APIs with trait-driven facades, proving parity through existing audio regression tests and ensuring no direct OS calls remain.
 - **Phase 1d – Serialization contract hardening (≈1 engineer-week)**: Define and snapshot serialization contracts for state snapshots, world chunks, player data, and asset tables, ensuring compatibility with Unreal data structures and capturing golden files for deterministic comparison.
-- **Exit gate**: Phase 1 concludes only when a determinism regression harness demonstrates identical tick outputs between the pre-refactor client and the abstracted `rust/core` workspace across two consecutive runs.
+- **Exit gate**: Phase 1 concludes only when a determinism regression harness demonstrates identical tick outputs between the pre-refactor client and the abstracted `rust/core` workspace across two consecutive runs using standardized test scenarios: (1) 100-tick world generation with fixed seed, (2) player movement and combat simulation, (3) weather and day/night cycle progression, with byte-for-byte output comparison and golden file validation.
 
 ### Phase 2 — FFI & Plugin Skeleton
 - Design the C ABI surface (init, tick, shutdown, event queues, data queries) using the FFI approach selected during the Phase 0 spike, then generate headers via `cbindgen` or UniFFI accordingly.

--- a/docs/ue5_plugin_migration_plan.md
+++ b/docs/ue5_plugin_migration_plan.md
@@ -1,0 +1,143 @@
+# UE5 Plugin Migration Roadmap
+
+## 1. Objectives & Guardrails
+- Produce a UE 5.6+ plugin that can be dropped into an Unreal project while preserving Rust-driven gameplay, networking, and data backends.
+- Keep non-UE-facing logic in Rust crates where it delivers value (deterministic gameplay, ECS systems, world simulation).
+- Replace all engine-facing systems (rendering, audio, input, networking replication) with Unreal-native implementations that integrate cleanly with Epic-sanctioned extension points.
+- Maintain compatibility with existing data tables, asset schemas, and save formats; provide conversion or binding layers when a 1:1 import is impossible.
+- Preserve current CI habits (format/lint/test) while expanding automation to cover the UE build pipeline and plugin packaging.
+
+## 2. Workspace Inventory & Boundaries
+### 2.1 Core crates to preserve as Rust libraries
+| Area | Crates/Paths | Notes |
+| --- | --- | --- |
+| Gameplay ECS & mechanics | `common/src` (combat, resources, weather, world interactions), `common/systems`, `common/ecs` | Pure gameplay logic/components already separated from rendering. |
+| Shared state & save logic | `common/state` (ECS world orchestration, serialized state, plugin hooks) | Holds authoritative state container reused by client/server. |
+| World simulation & generation | `world/src` (terrain, civ, site, simulation layers) | Deterministic procedural content suited for Rust static library. |
+| Networking protocol logic | `network/protocol` (message types, transport abstractions) | Serialization and prioritization rules reusable behind UE NetDriver bridge. |
+| Server gameplay | `server/src` and `server/agent` | Contains rules, NPC AI, quest flow to be exposed to UE through bindings. |
+| Databases/data tables | `assets/`, `common/assets`, `common/i18n` | Should be exposed to UE as DataAssets or referenced via Rust API. |
+
+### 2.2 Engine-locked crates to replace or wrap
+| Area | Crates/Paths | UE Migration Target |
+| --- | --- | --- |
+| Rendering & windowing | `voxygen` (wgpu renderer, winit input, egui UI), `voxygen/anim`, `voxygen/egui` | Replace with UE viewport, Nanite pipelines, UMG/Slate, Control Rig; leave only data definitions in Rust. |
+| Client runtime shell | `client` crate (window bootstrap, input loop) | Rebuild as UE GameInstance + PlayerController using Rust for logic only. |
+| Audio backend | `voxygen` uses `kira`+`cpal` | Route through UE AudioMixer and MetaSound assets. |
+| Networking transport | `network` uses `quinn` QUIC + tokio runtime | Bridge to UE replication (UDP) via C++ shim calling Rust protocol/state. |
+| Platform integrations | Discord SDK, native dialogs, winit-specific clipboard | Replace with UE OnlineSubsystem / platform APIs.
+
+## 3. Rust Dependencies Requiring UE Replacement
+| Subsystem | Key Crates | Unreal Replacement Strategy |
+| --- | --- | --- |
+| Graphics | `wgpu`, `shaderc`, `wgpu-profiler`, `glyph_brush` (text), `treeculler` (culling helpers) | Re-implement render flow with UE Render Graph/Nanite. Keep material/mesh metadata in Rust as data descriptors only. |
+| Windowing & Input | `winit`, `gilrs`, `iced`, `egui`, `conrod_core`, `window_clipboard` | Use UE Input System, Enhanced Input, Slate/UMG. Provide mapping layer so Rust gameplay systems receive input events via UE dispatch. |
+| Audio | `kira`, `cpal`, `mumble-link` | Use UE AudioMixer, MetaSound, and built-in VOIP integration. Rust publishes semantic audio cues consumed by UE. |
+| Networking | `quinn`, `tokio`, `tokio-stream`, `async-channel`, `rustls`, `lz-fear` | Replace transport with UE NetDriver/Replication. Rust logic exposes authoritative state diff/compression functions callable from UE. |
+| Platform Services | `discord-sdk`, `native-dialog`, `open`, OS-specific memory allocators | Implement via UE OnlineSubsystem, platform frameworks, or optional modules. |
+
+## 4. Game Logic & Systems to Preserve
+- **ECS components and systems**: `common/src/comp`, `common/src/systems`, and `common/ecs` define gameplay mechanics, stats, status effects, weather, tethering, etc. These should become the authoritative simulation compiled into a Rust static library that UE calls each tick.
+- **State orchestration**: `common/state/src/state.rs` coordinates ECS world creation, time stepping, and plugin hooks; expose this as FFI functions (e.g., `mw_state_init`, `mw_state_tick`) consumable from UE Actors or subsystems.
+- **World generation**: `world/src` modules (terrain, civ, sites, sim) remain Rust-driven, generating serialized world chunks that UE converts to Procedural Content (landscape meshes, foliage instances) via translation layers.
+- **Server gameplay**: `server/src` logic (missions, AI behaviors) should remain in Rust, callable either in dedicated server builds or via UE server modules linking against the Rust core.
+- **Shared data registries**: Items, recipes, weather tables, etc., stored under `common/assets`, `common/i18n`, and `assets/` should feed UE Data Assets or runtime registries by parsing existing RON/JSON/SQL via Rust and handing structured data to UE.
+
+## 5. Serializable Data & Interfaces to Map to UE
+- **Authoritative state snapshots** (`common/state/src/state.rs`): provide C ABI functions to fetch serialized ECS component data (player stats, inventories, terrain deltas) for UE replication.
+- **Player/account data** (`common/src/character.rs`, `common/src/resources.rs`, `common/src/trade.rs`): define FFI structs mirroring UE `USTRUCT` wrappers so gameplay ability systems can consume them.
+- **World terrain data** (`common/src/terrain`, `world/src/land.rs`, `world/src/block.rs`): translate voxel/chunk data into UE Landscape heightmaps or ProceduralMesh data, with Nanite-ready mesh baking.
+- **Network messages** (`network/protocol/src/message.rs`, `network/protocol/src/types.rs`): map to UE replicated RPCs and NetSerialize functions, preserving compression/prioritization schemes.
+- **Save/Load**: keep Rust serialization (RON/bincode) but expose hooks so UE save games trigger Rust persistence and receive file handles/metadata.
+
+## 6. Rendering Pipeline Extraction Tasks
+1. **Freeze Voxygen renderer**: treat `voxygen/src/render` and related shader assets as reference only; no further investment once migration branch starts.
+2. **Catalog render passes**: document meshes, terrain, UI, and post-processing passes within `voxygen/src/render/renderer` to know which data streams UE must drive (e.g., chunk meshing, particle emitters, UI overlays).
+3. **Define data contracts**: for each renderable (terrain chunk, entity mesh, particle), specify the minimal data Rust must expose (meshes, transforms, animation states) so UE’s Nanite, Niagara, and Material systems can consume them.
+4. **Input/event translation**: replace winit event loop with UE input mapping; ensure Rust receives sanitized inputs via FFI (e.g., `mw_apply_input(PlayerId, InputFrame)`).
+5. **Animation**: convert Veloren skeletal animation data (currently under `voxygen/anim`) into UE Skeleton/Animation Sequence assets, using data-driven Control Rig or IK solutions.
+
+## 7. Target Unreal Plugin Architecture
+### 7.1 Repository Layout Proposal
+```
+/Plugins/MajestikWorld/
+  MajestikWorld.uplugin
+  /Content           # UE assets (Nanite meshes, animations, Blueprints)
+  /Source
+    /MajestikWorld   # UE C++ layer: module, subsystem, Actor components
+      MajestikWorld.Build.cs
+      Public/
+      Private/
+    /MajestikWorldRust # Header-only shim generated via cbindgen for Rust APIs
+  /ThirdParty/RustCore
+    /lib              # Cargo builds output static/dynamic libs per platform
+    /include          # Generated C headers for Rust types/APIs
+/rust/
+  /core              # New Cargo workspace housing extracted gameplay/world crates
+  /unreal-bindings   # FFI crate exposing UE-facing API surface
+```
+
+### 7.2 Build & Toolchain Integration
+- Use `cargo` to build `rust/core` crates into static libs (`.a`/`.lib`) per platform; compile with `-C panic=abort` to match UE expectations.
+- Generate C headers with `cbindgen` (or `uniffi` if more ergonomic) and include them in `Source/MajestikWorldRust` for UE consumption.
+- Author `MajestikWorld.Build.cs` to detect Rust toolchain, invoke `cargo build --target` via pre-build step, and link outputs using `PublicAdditionalLibraries`.
+- Support Windows, Linux, and future console targets by configuring per-target cargo `config.toml` and UBT platform switches.
+
+### 7.3 Runtime Ownership Model
+- UE `UGameInstanceSubsystem` (C++) owns a pointer to Rust `State` (`mw_state_handle`).
+- Each tick, subsystem calls `mw_state_tick(delta)`; the Rust core returns event bundles (entity spawns/despawns, component updates) processed by UE to drive visuals and replication.
+- Use UE `UActorComponent` wrappers to mirror ECS components that need blueprint access (e.g., health, equipment). Components subscribe to update streams from Rust via event queues shared through FFI ring buffers.
+
+### 7.4 Networking & Replication Plan
+- Retire Rust’s QUIC socket management; designate UE server authoritative using existing NetDriver for connection/auth.
+- Rust networking crates degrade to deterministic state diff/compression utilities invoked by UE replication callbacks (e.g., `GetLifetimeReplicatedProps`).
+- Provide bridging layer translating `network/protocol` message structs into UE `FStruct`s, letting UE’s replication automatically deliver to clients while Rust handles simulation updates.
+
+### 7.5 Input, Audio, and UI Hooks
+- UE input actions produce normalized `InputFrame` data forwarded to Rust (per player) through FFI.
+- Rust emits semantic audio events (e.g., `PlaySound(SoundEventId, Position)`) captured by UE audio subsystem and played via MetaSound graphs.
+- Replace egui/iced UIs with UE UMG/Slate, reading Rust-provided data models (inventories, vendor lists) via asynchronous queries.
+
+### 7.6 Asset & Animation Strategy
+- Convert Voxel/VOX assets into Nanite meshes during content cooking; maintain original data for deterministic physics/hitboxes in Rust.
+- Use Veloren animation timelines as data-driven references to author UE Animation Sequences or Control Rig logic, storing mapping tables linking Rust animation state IDs to UE assets.
+- Keep localization tables by parsing `common/i18n` with Rust, then exporting to UE `Localization Dashboard` resources during build.
+
+## 8. Workflow, Testing, and CI Expansion
+- **Rust CI (existing):** keep `cargo fmt`, `cargo clippy --all-targets`, `cargo test --all`. Run inside `rust/` workspace.
+- **UE Build Verification:** add GitHub Actions job using Unreal Automation Tool (UAT) or `RunUAT BuildPlugin` to compile the plugin against UE 5.6 headless build (Linux container).
+- **Binding Consistency Test:** add integration test crate that links against generated C headers and ensures ABI compatibility (e.g., using `ctest`).
+- **Simulation Regression Tests:** keep deterministic worldgen/save-game tests in Rust; use golden outputs to ensure parity before and after UE integration.
+- **Packaging:** create CI artifact packaging plugin zip with built Rust libs for supported platforms.
+- **Branch Strategy:** create `ue5-migration` analysis branch for documentation and tooling while leaving existing Rust gameplay development on `main`; merge plan once executable path validated.
+
+## 9. Phased Migration Plan
+1. **Discovery & Documentation**
+   - Freeze `voxygen` feature work; document render/input/audio contracts.
+   - Produce binding specification for ECS components and network messages.
+2. **Rust Core Extraction**
+   - Factor gameplay/world crates into `rust/core` workspace with clean `no_std`-friendly boundaries where feasible.
+   - Remove direct dependencies on winit/wgpu/cpal from logic crates by introducing trait-based interfaces.
+3. **FFI Surface Definition**
+   - Design `extern "C"` API for state lifecycle, tick, event subscription, and data queries.
+   - Implement serialization bridging (RON/JSON/Bincode) to UE `FBufferArchive` / `FMemoryReader` wrappers.
+4. **UE Plugin Skeleton**
+   - Scaffold plugin folder with module classes, build script invoking cargo, and placeholder Blueprints/Content.
+   - Implement input forwarding, tick loop, and sample actor replicating Rust-driven NPC state.
+5. **Subsystem Migration**
+   - Replace networking: UE authoritative server calling Rust simulation.
+   - Replace audio: map Rust events to UE MetaSound.
+   - Replace UI/inventory: build UMG screens backed by Rust data snapshots.
+6. **Asset Conversion & Visual Upgrade**
+   - Batch convert meshes to Nanite, integrate Niagara particle systems using Rust event triggers.
+   - Port animation sets with Control Rig.
+7. **Stabilization & QA**
+   - Establish automated integration tests and performance baselines.
+   - Update documentation (`SPECS.md`, `README.md`, `AGENTS.md`) with new plugin workflow and guardrails.
+
+## 10. Immediate Next Actions
+- Approve this roadmap and create the `ue5-migration` branch dedicated to planning and tooling without blocking active Rust development.
+- Kick off dependency audit PRs that mark wgpu/winit/cpal usage sites for removal or abstraction.
+- Prototype `rust/core` static library exposing `mw_state_init/tick/shutdown` and validate linking from a minimal UE module via C API.
+- Begin asset pipeline research for VOX → Nanite conversion (e.g., MagicaVoxel → FBX/GLTF → UE Nanite) while preserving collision data for Rust physics.
+- Schedule documentation updates once the base FFI layer and plugin skeleton stabilize (per instructions for `SPECS.md`, `README.md`, `AGENTS.md`).


### PR DESCRIPTION
## Summary
- add a top-level PLAN.md that defines the strategic roadmap for transforming Majestik World into a UE 5.6+ plugin
- outline phased execution, cross-cutting workstreams, deliverables, and immediate actions aligned with the existing UE5 migration plan

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68cfb0ca4ba08322978b509ba12fe076