### PR TITLE
Expose terrain diff snapshots through UE5 FFI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3971,6 +3971,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58093314a45e00c77d5c508f76e77c3396afbbc0d01506e7fae47b018bac2b1d"
 
 [[package]]
+name = "majestic-world-core"
+version = "0.1.0"
+dependencies = [
+ "approx 0.5.1",
+ "specs",
+ "vek 0.17.1",
+ "veloren-common",
+ "veloren-common-state",
+]
+
+[[package]]
+name = "majestic-world-ffi"
+version = "0.1.0"
+dependencies = [
+ "majestic-world-core",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ members = [
     "world",
     "network",
     "network/protocol",
+    "rust/core",
+    "rust/unreal-bindings",
 ]
 
 ### PACKAGE ###

--- a/UE5_PLUGIN_MASTER_PLAN.md
+++ b/UE5_PLUGIN_MASTER_PLAN.md
@@ -79,5 +79,11 @@ This master plan establishes the end-to-end roadmap for transforming the existin
 3. **Rust static library prototype** — Produce a `rust/core` static library alongside generated headers using the selected FFI tooling, validated by a minimal UE or C harness that executes `mw_state_tick` and matches golden determinism snapshots. *Success criteria*: harness output checked into CI with pass/fail gating.
 4. **Documentation update plan** — Draft updates for SPECS.md/README.md/AGENTS.md outlining forthcoming workflow changes once prototypes succeed. *Success criteria*: merged documentation checklist that maps every artifact to an owner and milestone.
 
+## Implementation Task Tracker
+- [x] Expose chunk-level terrain diffs via `mw_core_last_terrain_diff_take`, including buffer ownership validation and leak-safe frees enforced by the registry-backed allocator.
+- [x] Harden FFI entry points with deterministic delta-time validation and explicit `MwResult` codes (`InvalidGameMode`, `BufferTooLarge`, `InvalidDeltaTime`) so UE callers receive actionable failures.
+- [ ] Wire the UE-side plugin prototype to consume the exported buffers and exercise the tick loop from an Unreal subsystem harness.
+- [ ] Expand CI with integration tests that link against the generated C headers and execute regression snapshots across Rust and UE builds.
+
 ---
 *This master plan will be revisited after Phase 2 prototypes validate the Rust ⇄ UE integration strategy, at which point documentation updates and downstream tasks will be scheduled.*

--- a/UE5_PLUGIN_MASTER_PLAN.md
+++ b/UE5_PLUGIN_MASTER_PLAN.md
@@ -3,6 +3,11 @@
 ## Purpose & Scope
 This master plan establishes the end-to-end roadmap for transforming the existing Majestik World (Veloren fork) workspace into a drop-in Unreal Engine 5.6+ plugin while preserving and extending our Rust-based gameplay foundation. It aligns engineering, content, and operations teams around shared milestones, defines guardrails for cross-language integration, and identifies the documentation and CI updates required once the base plan solidifies.
 
+## Governance & Contacts
+- **Plan owner:** GitHub user [`beyawnko`](https://github.com/beyawnko) serves as the sole developer and point of contact for stakeholder alignment across the UE5 migration effort.
+- **Licensing inquiries:** Direct all licensing or redistribution questions to `beyawnko`; they retain full ownership of the codebase and associated plans during the migration.
+- **Repository visibility:** The repository is scheduled to transition to private visibility once Phase 2 prototypes validate the integration strategy, so contributors should archive any required public artifacts ahead of that milestone.
+
 ## Strategic Objectives
 1. **Deliver a UE 5.6+ plugin** that exposes Majestik World's Rust gameplay, networking, and world simulation through Epic-sanctioned extension points.
 2. **Retain deterministic Rust systems** for non-UE-facing logic, exposing them via safe FFI bridges that follow Unreal plugin standards and are backed by automated regression tests that verify identical simulation outputs pre- and post-UE integration.

--- a/docs/ue5_plugin_migration_plan.md
+++ b/docs/ue5_plugin_migration_plan.md
@@ -54,6 +54,7 @@
 - **Authoritative state snapshots** (`common/state/src/state.rs`): provide C ABI functions to fetch serialized ECS component data (player stats, inventories, terrain deltas) for UE replication.
 - **Player/account data** (`common/src/character.rs`, `common/src/resources.rs`, `common/src/trade.rs`): define FFI structs mirroring UE `USTRUCT` wrappers so gameplay ability systems can consume them.
 - **World terrain data** (`common/src/terrain`, `world/src/land.rs`, `world/src/block.rs`): translate voxel/chunk data into UE Landscape heightmaps or ProceduralMesh data, with Nanite-ready mesh baking.
+  - The Phase 1 core crate now snapshots chunk-level terrain diffs each tick and exposes them via `mw_core_last_terrain_diff_take`, delivering sorted chunk coordinates through FFI-managed buffers ready for UE consumption.
 - **Network messages** (`network/protocol/src/message.rs`, `network/protocol/src/types.rs`): map to UE replicated RPCs and NetSerialize functions, preserving compression/prioritization schemes.
 - **Save/Load**: keep Rust serialization (RON/bincode) but expose hooks so UE save games trigger Rust persistence and receive file handles/metadata.
 

--- a/docs/ue5_plugin_migration_plan.md
+++ b/docs/ue5_plugin_migration_plan.md
@@ -1,5 +1,7 @@
 # UE5 Plugin Migration Roadmap
 
+> **Governance note:** GitHub user [`beyawnko`](https://github.com/beyawnko) is the sole developer and stakeholder contact for this roadmap. Direct licensing or redistribution questions to `beyawnko`. The repository will transition to private visibility once the Phase 2 integration spike is validated, so ensure required public references are archived beforehand.
+
 ## 1. Objectives & Guardrails
 - Produce a UE 5.6+ plugin that can be dropped into an Unreal project while preserving Rust-driven gameplay, networking, and data backends.
 - Keep non-UE-facing logic in Rust crates where it delivers value (deterministic gameplay, ECS systems, world simulation).

--- a/docs/ue5_plugin_migration_plan.md
+++ b/docs/ue5_plugin_migration_plan.md
@@ -157,3 +157,10 @@
 3. **Rust core prototype** — Prototype a `rust/core` static library exposing `mw_state_init/tick/shutdown` and validate linking from a minimal UE (or C) harness via the selected FFI tooling. *Success criteria*: automated test harness producing deterministic tick snapshots stored under CI artifacts.
 4. **Asset pipeline experiment** — Begin asset pipeline research for VOX → Nanite conversion (e.g., MagicaVoxel → FBX/GLTF → UE Nanite) while preserving collision data for Rust physics. *Success criteria*: documented pipeline prototype with sample asset conversion and comparison screenshots/metrics.
 5. **Documentation scheduling** — Schedule documentation updates once the base FFI layer and plugin skeleton stabilize (per instructions for `SPECS.md`, `README.md`, `AGENTS.md`). *Success criteria*: shared checklist mapping each document update to a milestone and owner within the migration tracker.
+
+## UE5 Migration Task List
+- [x] Finalise terrain diff streaming across the FFI boundary with leak-safe buffer ownership and explicit `MwResult` errors for oversize exports.
+- [x] Gate Unreal tick integration behind deterministic delta-time validation (finite, non-negative, capped at `MAX_DELTA_TIME_SECONDS`, subnormal-aware) so runaway frames are rejected.
+- [x] Add nightly-aware gating for `unsafe(no_mangle)` exports, keeping stable compilers on the safe code path while preserving nightly builds for ABI validation.
+- [ ] Generate and publish the C header set for the exported APIs alongside example UE subsystem glue.
+- [ ] Stand up UE-side harnesses that consume chunk diff buffers each frame and assert determinism against the Rust-only golden snapshots.

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,4 +1,4 @@
-# Majestik World UE5 Core Workspace
+# Majestic World UE5 Core Workspace
 
 This directory hosts the additive crates introduced for the UE5 migration
 roadmap documented in `UE5_PLUGIN_MASTER_PLAN.md` and

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,0 +1,18 @@
+# Majestik World UE5 Core Workspace
+
+This directory hosts the additive crates introduced for the UE5 migration
+roadmap documented in `UE5_PLUGIN_MASTER_PLAN.md` and
+`docs/ue5_plugin_migration_plan.md`.
+
+- `core/` exposes `majestic-world-core`, a deterministic gameplay façade around
+  Veloren's existing `State` type (Phase 1a/1d). It now snapshots terrain chunk
+  diffs each tick so downstream bindings can stream world updates without
+  inspecting internal ECS resources directly.
+- `unreal-bindings/` exposes `majestic-world-ffi`, a stable C ABI surface for
+  Unreal Engine integration experiments (Phase 2). The FFI exports terrain
+  change buffers as heap-allocated arrays that UE-side callers can consume and
+  free explicitly, matching the migration plan's data-contract goals.
+
+Both crates compile as part of the top-level Cargo workspace and deliberately
+avoid linking to client rendering or platform code, aligning with the migration
+plan's requirement to decouple the simulation from `voxygen`.

--- a/rust/core/Cargo.toml
+++ b/rust/core/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "majestic-world-core"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+veloren-common = { path = "../../common", package = "veloren-common" }
+veloren-common-state = { path = "../../common/state", package = "veloren-common-state" }
+specs = { workspace = true }
+vek = { workspace = true }
+
+[dev-dependencies]
+approx = "0.5"

--- a/rust/core/Cargo.toml
+++ b/rust/core/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [features]
 default = []
-ffi-test-hooks = []
+test-only-unsafe-hooks = []
 
 [lints]
 workspace = true

--- a/rust/core/Cargo.toml
+++ b/rust/core/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition.workspace = true
 publish = false
 
+[features]
+default = []
+ffi-test-hooks = []
+
 [lints]
 workspace = true
 

--- a/rust/core/src/lib.rs
+++ b/rust/core/src/lib.rs
@@ -1,0 +1,317 @@
+//! Core Rust library surface for the Majestik World UE5 migration.
+//!
+//! This crate begins the Phase 1a/1d work described in
+//! `docs/ue5_plugin_migration_plan.md`, extracting a deterministic simulation
+//! interface that can be linked from external runtimes.
+
+use std::{fmt, sync::Arc, time::Duration};
+
+use specs::{World, world::WorldExt};
+use veloren_common::{
+    resources::{GameMode as VelorenGameMode, ProgramTime, Time, TimeOfDay},
+    terrain::{MapSizeLg, TerrainChunk},
+};
+use veloren_common_state::{State, TerrainChanges};
+
+/// Integer grid coordinate describing a terrain chunk.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct TerrainChunkCoord {
+    /// Chunk coordinate along the X axis.
+    pub x: i32,
+    /// Chunk coordinate along the Y axis.
+    pub y: i32,
+}
+
+impl TerrainChunkCoord {
+    /// Create a new chunk coordinate instance.
+    pub const fn new(x: i32, y: i32) -> Self { Self { x, y } }
+}
+
+/// Snapshot of terrain diffs produced during a simulation tick.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct TerrainDiff {
+    /// Coordinates of chunks inserted during the tick.
+    pub new_chunks: Vec<TerrainChunkCoord>,
+    /// Coordinates of chunks modified during the tick.
+    pub modified_chunks: Vec<TerrainChunkCoord>,
+    /// Coordinates of chunks removed during the tick.
+    pub removed_chunks: Vec<TerrainChunkCoord>,
+}
+
+impl TerrainDiff {
+    fn from_terrain_changes(changes: &TerrainChanges) -> Self {
+        fn collect_chunks<'a>(
+            iter: impl Iterator<Item = &'a vek::Vec2<i32>>,
+        ) -> Vec<TerrainChunkCoord> {
+            let mut coords: Vec<_> = iter
+                .map(|pos| TerrainChunkCoord::new(pos.x, pos.y))
+                .collect();
+            coords.sort_unstable_by(|lhs, rhs| lhs.x.cmp(&rhs.x).then_with(|| lhs.y.cmp(&rhs.y)));
+            coords
+        }
+
+        Self {
+            new_chunks: collect_chunks(changes.new_chunks.iter()),
+            modified_chunks: collect_chunks(changes.modified_chunks.iter()),
+            removed_chunks: collect_chunks(changes.removed_chunks.iter()),
+        }
+    }
+
+    /// Whether the diff contains no changes.
+    pub fn is_empty(&self) -> bool {
+        self.new_chunks.is_empty()
+            && self.modified_chunks.is_empty()
+            && self.removed_chunks.is_empty()
+    }
+}
+
+/// Configuration used when instantiating a [`MajestikCore`] simulation handle.
+#[derive(Clone, Copy, Debug)]
+pub struct CoreInitConfig {
+    /// Base two logarithm of the desired world dimensions in chunks.
+    pub map_size_lg: vek::Vec2<u32>,
+    /// Sea level used when building the fallback terrain chunk.
+    pub sea_level: i32,
+    /// Day/night speed multiplier relative to real time.
+    pub day_cycle_coefficient: f64,
+    /// Which gameplay mode to initialise the underlying state with.
+    pub game_mode: VelorenGameMode,
+}
+
+impl Default for CoreInitConfig {
+    fn default() -> Self {
+        Self {
+            map_size_lg: vek::Vec2::new(1, 1),
+            sea_level: 0,
+            day_cycle_coefficient: 1.0,
+            game_mode: VelorenGameMode::Server,
+        }
+    }
+}
+
+impl CoreInitConfig {
+    /// Convenience constructor that avoids exposing the `vek` dependency at
+    /// FFI boundaries.
+    pub fn from_components(
+        map_size_lg_x: u32,
+        map_size_lg_y: u32,
+        sea_level: i32,
+        day_cycle_coefficient: f64,
+        game_mode: VelorenGameMode,
+    ) -> Self {
+        Self {
+            map_size_lg: vek::Vec2::new(map_size_lg_x, map_size_lg_y),
+            sea_level,
+            day_cycle_coefficient,
+            game_mode,
+        }
+    }
+}
+
+/// Errors produced when constructing a [`MajestikCore`] instance.
+#[derive(Debug, PartialEq, Eq)]
+pub enum CoreInitError {
+    /// The requested `map_size_lg` violated the invariants enforced by
+    /// [`MapSizeLg::new`].
+    InvalidMapSize,
+    /// The provided day/night cycle multiplier was zero, negative, or not
+    /// finite.
+    InvalidDayCycleCoefficient,
+}
+
+impl fmt::Display for CoreInitError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidMapSize => f.write_str("map_size_lg outside supported range"),
+            Self::InvalidDayCycleCoefficient => {
+                f.write_str("day_cycle_coefficient must be finite and positive")
+            },
+        }
+    }
+}
+
+impl std::error::Error for CoreInitError {}
+
+/// Options that influence how a simulation tick executes.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct TickConfig {
+    /// Whether terrain diffs generated during the tick should be applied
+    /// immediately.
+    pub update_terrain: bool,
+}
+
+/// Deterministic gameplay core that is safe to expose across FFI boundaries.
+pub struct MajestikCore {
+    state: State,
+    server_constants: veloren_common::shared_server_config::ServerConstants,
+    game_mode: VelorenGameMode,
+    last_terrain_diff: TerrainDiff,
+}
+
+impl MajestikCore {
+    /// Create a new Majestik simulation core using the supplied configuration.
+    pub fn new(config: CoreInitConfig) -> Result<Self, CoreInitError> {
+        if !config.day_cycle_coefficient.is_finite() || config.day_cycle_coefficient <= 0.0 {
+            return Err(CoreInitError::InvalidDayCycleCoefficient);
+        }
+
+        let map_size =
+            MapSizeLg::new(config.map_size_lg).map_err(|_| CoreInitError::InvalidMapSize)?;
+        let pools = State::pools(config.game_mode);
+
+        let mut state = State::new(
+            config.game_mode,
+            Arc::clone(&pools),
+            map_size,
+            Arc::new(TerrainChunk::water(config.sea_level)),
+            |_| {},
+        );
+
+        // Ensure the `TerrainChanges` resource starts cleared before the first
+        // integration step, mirroring the cleanup performed in `tick`.
+        state.ecs_mut().write_resource::<TerrainChanges>().clear();
+
+        Ok(Self {
+            state,
+            server_constants: veloren_common::shared_server_config::ServerConstants {
+                day_cycle_coefficient: config.day_cycle_coefficient,
+            },
+            game_mode: config.game_mode,
+            last_terrain_diff: TerrainDiff::default(),
+        })
+    }
+
+    /// Returns the [`GameMode`] with which this core was initialised.
+    pub fn game_mode(&self) -> VelorenGameMode { self.game_mode }
+
+    /// Advance the simulation by the provided duration.
+    pub fn tick(&mut self, dt: Duration, config: TickConfig) {
+        self.state.tick(
+            dt,
+            config.update_terrain,
+            None,
+            &self.server_constants,
+            |_, _| {},
+        );
+        self.snapshot_last_terrain_diff();
+        self.state.cleanup();
+    }
+
+    /// Read the accumulated simulation time in seconds.
+    pub fn time_seconds(&self) -> f64 { self.state.ecs().read_resource::<Time>().0 }
+
+    /// Read the accumulated in-game time-of-day in seconds.
+    pub fn time_of_day_seconds(&self) -> f64 { self.state.ecs().read_resource::<TimeOfDay>().0 }
+
+    /// Read the accumulated program time in seconds.
+    pub fn program_time_seconds(&self) -> f64 { self.state.ecs().read_resource::<ProgramTime>().0 }
+
+    /// Provide shared access to the underlying ECS world for read-only queries.
+    pub fn visit_world<R>(&self, visitor: impl FnOnce(&World) -> R) -> R {
+        visitor(self.state.ecs())
+    }
+
+    fn snapshot_last_terrain_diff(&mut self) {
+        let diff = {
+            let changes = self.state.ecs().read_resource::<TerrainChanges>();
+            TerrainDiff::from_terrain_changes(&changes)
+        };
+        self.last_terrain_diff = diff;
+    }
+
+    /// Read the terrain diff captured during the previous tick.
+    pub fn last_terrain_diff(&self) -> &TerrainDiff { &self.last_terrain_diff }
+
+    /// Take the previously captured terrain diff, resetting the internal cache.
+    pub fn take_last_terrain_diff(&mut self) -> TerrainDiff {
+        std::mem::take(&mut self.last_terrain_diff)
+    }
+}
+
+pub use veloren_common::resources::GameMode;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_abs_diff_eq;
+
+    #[test]
+    fn rejects_invalid_map_size() {
+        let config = CoreInitConfig {
+            map_size_lg: vek::Vec2::new(32, 32),
+            ..CoreInitConfig::default()
+        };
+        assert!(matches!(
+            MajestikCore::new(config),
+            Err(CoreInitError::InvalidMapSize)
+        ));
+    }
+
+    #[test]
+    fn rejects_invalid_day_cycle() {
+        let config = CoreInitConfig {
+            day_cycle_coefficient: 0.0,
+            ..CoreInitConfig::default()
+        };
+        assert!(matches!(
+            MajestikCore::new(config),
+            Err(CoreInitError::InvalidDayCycleCoefficient)
+        ));
+
+        let config = CoreInitConfig {
+            day_cycle_coefficient: f64::NAN,
+            ..CoreInitConfig::default()
+        };
+        assert!(matches!(
+            MajestikCore::new(config),
+            Err(CoreInitError::InvalidDayCycleCoefficient)
+        ));
+    }
+
+    #[test]
+    fn tick_advances_time_deterministically() {
+        let mut core = MajestikCore::new(CoreInitConfig::default()).expect("core initialises");
+        let start_sim = core.time_seconds();
+        let start_prog = core.program_time_seconds();
+
+        let dt = Duration::from_millis(16);
+        core.tick(dt, TickConfig::default());
+
+        let end_sim = core.time_seconds();
+        let end_prog = core.program_time_seconds();
+
+        assert_abs_diff_eq!(end_prog - start_prog, dt.as_secs_f64(), epsilon = 1e-9);
+        assert!(end_sim > start_sim);
+    }
+
+    #[test]
+    fn terrain_diff_sorting_is_stable() {
+        let mut changes = TerrainChanges::default();
+        changes.new_chunks.insert(vek::Vec2::new(2, -5));
+        changes.new_chunks.insert(vek::Vec2::new(-3, 4));
+        changes.new_chunks.insert(vek::Vec2::new(-3, 2));
+
+        let diff = TerrainDiff::from_terrain_changes(&changes);
+        assert_eq!(diff.new_chunks, vec![
+            TerrainChunkCoord::new(-3, 2),
+            TerrainChunkCoord::new(-3, 4),
+            TerrainChunkCoord::new(2, -5),
+        ]);
+    }
+
+    #[test]
+    fn snapshot_and_take_terrain_diff() {
+        let mut core = MajestikCore::new(CoreInitConfig::default()).expect("core initialises");
+        {
+            let mut terrain_changes = core.state.ecs_mut().write_resource::<TerrainChanges>();
+            terrain_changes
+                .modified_chunks
+                .insert(vek::Vec2::new(7, -1));
+        }
+
+        core.snapshot_last_terrain_diff();
+        let diff = core.take_last_terrain_diff();
+        assert_eq!(diff.modified_chunks, vec![TerrainChunkCoord::new(7, -1)]);
+        assert!(core.take_last_terrain_diff().is_empty());
+    }
+}

--- a/rust/core/src/lib.rs
+++ b/rust/core/src/lib.rs
@@ -219,6 +219,12 @@ impl MajestikCore {
     /// the world outside the closure, eliminating a common class of
     /// use-after-free bugs when integrating with foreign runtimes.
     ///
+    /// **Owned data** includes primitive scalars (`i32`, `f64`), owned
+    /// containers (`String`, `Vec<T>`), and composite structs that contain only
+    /// owned fields. **Borrowed data** includes references (`&T`, `&str`,
+    /// `&[T]`), Specs component handles, iterators that borrow from the world,
+    /// or any type carrying a lifetime parameter tied to the ECS.
+    ///
     /// # Safety
     /// The provided closure must not retain references, Specs handles, or
     /// iterators that borrow from the `World` beyond this call, nor may it
@@ -275,15 +281,15 @@ impl MajestikCore {
     }
 }
 
-#[cfg(feature = "ffi-test-hooks")]
+#[cfg(feature = "test-only-unsafe-hooks")]
 impl MajestikCore {
     /// Inject a preconstructed terrain diff for test instrumentation.
     ///
     /// # Warning
-    /// This helper is gated behind the `ffi-test-hooks` feature and must never
-    /// be enabled in production builds. Forcing arbitrary diffs into the core
-    /// bypasses the normal capture pipeline and can desynchronise terrain state
-    /// if abused outside controlled tests.
+    /// This helper is gated behind the `test-only-unsafe-hooks` feature and
+    /// must never be enabled in production builds. Forcing arbitrary diffs
+    /// into the core bypasses the normal capture pipeline and can
+    /// desynchronise terrain state if abused outside controlled tests.
     pub fn inject_last_terrain_diff_for_test(&mut self, diff: TerrainDiff) {
         self.last_terrain_diff = diff;
     }

--- a/rust/core/src/lib.rs
+++ b/rust/core/src/lib.rs
@@ -216,6 +216,12 @@ impl MajestikCore {
     /// prevents callers from leaking references tied to the world outside
     /// the closure, eliminating a common class of use-after-free bugs when
     /// integrating with foreign runtimes.
+    ///
+    /// # Safety
+    /// The provided closure must not retain references, Specs handles, or
+    /// iterators that borrow from the `World` beyond this call, nor may it
+    /// invoke APIs that mutate the ECS. Doing so would desynchronise the
+    /// simulation state from external runtimes.
     pub fn query_world_owned<R>(&self, visitor: impl FnOnce(&World) -> R) -> R
     where
         R: Send + 'static,
@@ -244,7 +250,7 @@ impl MajestikCore {
 impl MajestikCore {
     /// Inject a preconstructed terrain diff for test instrumentation.
     ///
-    /// # Safety
+    /// # Warning
     /// This helper is gated behind the `ffi-test-hooks` feature and must never
     /// be enabled in production builds. Forcing arbitrary diffs into the core
     /// bypasses the normal capture pipeline and can desynchronise terrain state

--- a/rust/unreal-bindings/Cargo.toml
+++ b/rust/unreal-bindings/Cargo.toml
@@ -15,4 +15,4 @@ crate-type = ["staticlib", "cdylib"]
 majestic-world-core = { path = "../core" }
 
 [dev-dependencies]
-majestic-world-core = { path = "../core", features = ["ffi-test-hooks"] }
+majestic-world-core = { path = "../core", features = ["test-only-unsafe-hooks"] }

--- a/rust/unreal-bindings/Cargo.toml
+++ b/rust/unreal-bindings/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "majestic-world-ffi"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[lib]
+crate-type = ["staticlib"]
+
+[dependencies]
+majestic-world-core = { path = "../core" }

--- a/rust/unreal-bindings/Cargo.toml
+++ b/rust/unreal-bindings/Cargo.toml
@@ -12,3 +12,6 @@ crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
 majestic-world-core = { path = "../core" }
+
+[dev-dependencies]
+majestic-world-core = { path = "../core", features = ["ffi-test-hooks"] }

--- a/rust/unreal-bindings/Cargo.toml
+++ b/rust/unreal-bindings/Cargo.toml
@@ -3,6 +3,7 @@ name = "majestic-world-ffi"
 version = "0.1.0"
 edition.workspace = true
 publish = false
+build = "build.rs"
 
 [lints]
 workspace = true

--- a/rust/unreal-bindings/Cargo.toml
+++ b/rust/unreal-bindings/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 workspace = true
 
 [lib]
-crate-type = ["staticlib"]
+crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
 majestic-world-core = { path = "../core" }

--- a/rust/unreal-bindings/build.rs
+++ b/rust/unreal-bindings/build.rs
@@ -1,8 +1,18 @@
 use std::process::Command;
 
+fn rustc_path_is_safe(rustc: &str) -> bool {
+    !rustc.is_empty()
+        && !rustc
+            .chars()
+            .any(|ch| matches!(ch, ';' | '&' | '|' | '`' | '$' | '>' | '<' | '\n' | '\r'))
+}
+
 fn main() {
     println!("cargo:rustc-check-cfg=cfg(ffi_use_unsafe_attributes)");
     let rustc = std::env::var("RUSTC").unwrap_or_else(|_| "rustc".to_string());
+    if !rustc_path_is_safe(&rustc) {
+        panic!("refusing to execute rustc with potentially malicious path: {rustc}");
+    }
     let channel = Command::new(rustc)
         .arg("--version")
         .output()
@@ -12,5 +22,22 @@ fn main() {
 
     if channel.contains("nightly") || channel.contains("dev") {
         println!("cargo:rustc-cfg=ffi_use_unsafe_attributes");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::rustc_path_is_safe;
+
+    #[test]
+    fn accepts_normal_rustc_paths() {
+        assert!(rustc_path_is_safe("/usr/bin/rustc"));
+        assert!(rustc_path_is_safe("C:/Program Files/Rust/bin/rustc.exe"));
+    }
+
+    #[test]
+    fn rejects_paths_with_shell_metacharacters() {
+        assert!(!rustc_path_is_safe("/usr/bin/rustc;rm -rf /"));
+        assert!(!rustc_path_is_safe("rustc|malicious"));
     }
 }

--- a/rust/unreal-bindings/build.rs
+++ b/rust/unreal-bindings/build.rs
@@ -2,9 +2,39 @@ use std::process::Command;
 
 fn rustc_path_is_safe(rustc: &str) -> bool {
     !rustc.is_empty()
-        && !rustc
-            .chars()
-            .any(|ch| matches!(ch, ';' | '&' | '|' | '`' | '$' | '>' | '<' | '\n' | '\r'))
+        && !rustc.chars().any(|ch| {
+            matches!(
+                ch,
+                ';' | '&'
+                    | '|'
+                    | '`'
+                    | '$'
+                    | '>'
+                    | '<'
+                    | '\n'
+                    | '\r'
+                    | '\0'
+                    | '\t'
+                    | '"'
+                    | '\''
+                    | '\\'
+                    | '*'
+                    | '?'
+                    | '['
+                    | ']'
+                    | '{'
+                    | '}'
+                    | '('
+                    | ')'
+                    | '~'
+                    | '#'
+                    | '!'
+                    | '%'
+            )
+        })
+        && !rustc.contains("..")
+        && !rustc.starts_with('-')
+        && rustc.len() < 4_096
 }
 
 fn main() {
@@ -39,5 +69,41 @@ mod tests {
     fn rejects_paths_with_shell_metacharacters() {
         assert!(!rustc_path_is_safe("/usr/bin/rustc;rm -rf /"));
         assert!(!rustc_path_is_safe("rustc|malicious"));
+    }
+
+    #[test]
+    fn rejects_additional_dangerous_characters() {
+        assert!(!rustc_path_is_safe("rustc\0malicious"));
+        assert!(!rustc_path_is_safe("rustc\"evil"));
+        assert!(!rustc_path_is_safe("rustc'bad'"));
+        assert!(!rustc_path_is_safe("rustc\\inject"));
+        assert!(!rustc_path_is_safe("rustc*glob"));
+        assert!(!rustc_path_is_safe("rustc?wildcard"));
+        assert!(!rustc_path_is_safe("rustc[range]"));
+        assert!(!rustc_path_is_safe("rustc{expansion}"));
+        assert!(!rustc_path_is_safe("rustc(subshell)"));
+        assert!(!rustc_path_is_safe("rustc~home"));
+        assert!(!rustc_path_is_safe("rustc#fragment"));
+        assert!(!rustc_path_is_safe("rustc!history"));
+        assert!(!rustc_path_is_safe("rustc%env"));
+    }
+
+    #[test]
+    fn rejects_path_traversal_attempts() {
+        assert!(!rustc_path_is_safe("/usr/bin/../../../bin/sh"));
+        assert!(!rustc_path_is_safe("../rustc"));
+        assert!(!rustc_path_is_safe("rustc/../evil"));
+    }
+
+    #[test]
+    fn rejects_flag_injection() {
+        assert!(!rustc_path_is_safe("-Zprint-link-args"));
+        assert!(!rustc_path_is_safe("--help"));
+    }
+
+    #[test]
+    fn rejects_oversized_paths() {
+        let oversized = "a".repeat(4_097);
+        assert!(!rustc_path_is_safe(&oversized));
     }
 }

--- a/rust/unreal-bindings/build.rs
+++ b/rust/unreal-bindings/build.rs
@@ -1,0 +1,16 @@
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rustc-check-cfg=cfg(ffi_use_unsafe_attributes)");
+    let rustc = std::env::var("RUSTC").unwrap_or_else(|_| "rustc".to_string());
+    let channel = Command::new(rustc)
+        .arg("--version")
+        .output()
+        .ok()
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .unwrap_or_default();
+
+    if channel.contains("nightly") || channel.contains("dev") {
+        println!("cargo:rustc-cfg=ffi_use_unsafe_attributes");
+    }
+}

--- a/rust/unreal-bindings/src/lib.rs
+++ b/rust/unreal-bindings/src/lib.rs
@@ -1,3 +1,6 @@
+#![cfg_attr(ffi_use_unsafe_attributes, allow(stable_features))]
+#![cfg_attr(ffi_use_unsafe_attributes, feature(unsafe_attributes))]
+
 //! C ABI bindings for the Majestik World core library.
 //!
 //! The exported functions provide the `init/tick/shutdown` loop described in

--- a/rust/unreal-bindings/src/lib.rs
+++ b/rust/unreal-bindings/src/lib.rs
@@ -1,0 +1,464 @@
+//! C ABI bindings for the Majestik World core library.
+//!
+//! The exported functions provide the `init/tick/shutdown` loop described in
+//! `UE5_PLUGIN_MASTER_PLAN.md` Phase 2 and `docs/ue5_plugin_migration_plan.md`
+//! §7, enabling Unreal Engine prototypes to call into the Rust simulation.
+
+use std::time::Duration;
+
+use majestic_world_core::{
+    CoreInitConfig, GameMode, MajestikCore, TerrainChunkCoord, TerrainDiff, TickConfig,
+};
+
+/// Result codes returned by the FFI surface.
+#[repr(i32)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MwResult {
+    Success = 0,
+    NullPointer = 1,
+    InvalidMapSize = 2,
+    InvalidDayCycle = 3,
+    InvalidDeltaTime = 4,
+    InternalError = 255,
+}
+
+impl From<majestic_world_core::CoreInitError> for MwResult {
+    fn from(err: majestic_world_core::CoreInitError) -> Self {
+        match err {
+            majestic_world_core::CoreInitError::InvalidMapSize => Self::InvalidMapSize,
+            majestic_world_core::CoreInitError::InvalidDayCycleCoefficient => Self::InvalidDayCycle,
+        }
+    }
+}
+
+/// Boolean type used across the ABI (0 = false, non-zero = true).
+pub type MwBool = u8;
+
+/// UE-facing representation of [`GameMode`].
+#[repr(i32)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MwGameMode {
+    Server = 0,
+    Client = 1,
+    Singleplayer = 2,
+}
+
+impl From<MwGameMode> for GameMode {
+    fn from(mode: MwGameMode) -> Self {
+        match mode {
+            MwGameMode::Server => GameMode::Server,
+            MwGameMode::Client => GameMode::Client,
+            MwGameMode::Singleplayer => GameMode::Singleplayer,
+        }
+    }
+}
+
+impl From<GameMode> for MwGameMode {
+    fn from(mode: GameMode) -> Self {
+        match mode {
+            GameMode::Server => MwGameMode::Server,
+            GameMode::Client => MwGameMode::Client,
+            GameMode::Singleplayer => MwGameMode::Singleplayer,
+        }
+    }
+}
+
+/// Configuration payload consumed by [`mw_core_create`].
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub struct MwCoreConfig {
+    pub map_size_lg_x: u32,
+    pub map_size_lg_y: u32,
+    pub sea_level: i32,
+    pub day_cycle_coefficient: f64,
+    pub game_mode: MwGameMode,
+}
+
+impl Default for MwCoreConfig {
+    fn default() -> Self {
+        Self {
+            map_size_lg_x: 1,
+            map_size_lg_y: 1,
+            sea_level: 0,
+            day_cycle_coefficient: 1.0,
+            game_mode: MwGameMode::Server,
+        }
+    }
+}
+
+impl MwCoreConfig {
+    fn into_core_config(self) -> CoreInitConfig {
+        CoreInitConfig::from_components(
+            self.map_size_lg_x,
+            self.map_size_lg_y,
+            self.sea_level,
+            self.day_cycle_coefficient,
+            self.game_mode.into(),
+        )
+    }
+}
+
+/// Coordinate pair describing a changed terrain chunk.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct MwTerrainChunkCoord {
+    pub x: i32,
+    pub y: i32,
+}
+
+impl From<TerrainChunkCoord> for MwTerrainChunkCoord {
+    fn from(coord: TerrainChunkCoord) -> Self {
+        Self {
+            x: coord.x,
+            y: coord.y,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct MwTerrainChunkBuffer {
+    pub ptr: *mut MwTerrainChunkCoord,
+    pub len: usize,
+}
+
+impl MwTerrainChunkBuffer {
+    fn from_vec(coords: Vec<MwTerrainChunkCoord>) -> Self {
+        if coords.is_empty() {
+            Self {
+                ptr: std::ptr::null_mut(),
+                len: 0,
+            }
+        } else {
+            let len = coords.len();
+            let mut boxed = coords.into_boxed_slice();
+            let ptr = boxed.as_mut_ptr();
+            std::mem::forget(boxed);
+            Self { ptr, len }
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct MwTerrainDiff {
+    pub new_chunks: MwTerrainChunkBuffer,
+    pub modified_chunks: MwTerrainChunkBuffer,
+    pub removed_chunks: MwTerrainChunkBuffer,
+}
+
+/// Opaque handle stored by foreign runtimes.
+#[repr(C)]
+pub struct MwState {
+    inner: MajestikCore,
+}
+
+fn write_out_ptr<T>(out: *mut *mut T, value: Box<T>) -> MwResult {
+    if let Some(slot) = unsafe { out.as_mut() } {
+        *slot = Box::into_raw(value);
+        MwResult::Success
+    } else {
+        MwResult::NullPointer
+    }
+}
+
+/// Populate a configuration struct with default values.
+///
+/// # Safety
+/// `out_config` must be a valid, writable pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mw_core_config_default(out_config: *mut MwCoreConfig) -> MwResult {
+    if let Some(out) = unsafe { out_config.as_mut() } {
+        *out = MwCoreConfig::default();
+        MwResult::Success
+    } else {
+        MwResult::NullPointer
+    }
+}
+
+/// Create a new [`MajestikCore`] instance and return an opaque handle.
+///
+/// # Safety
+/// `config` and `out_state` must be null or point to valid memory owned by the
+/// caller.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mw_core_create(
+    config: *const MwCoreConfig,
+    out_state: *mut *mut MwState,
+) -> MwResult {
+    let cfg = unsafe { config.as_ref() }.copied().unwrap_or_default();
+
+    match MajestikCore::new(cfg.into_core_config()) {
+        Ok(core) => write_out_ptr(out_state, Box::new(MwState { inner: core })),
+        Err(err) => err.into(),
+    }
+}
+
+/// Destroy a previously created [`MwState`].
+///
+/// # Safety
+/// `state` must be a pointer previously returned by [`mw_core_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mw_core_destroy(state: *mut MwState) {
+    if !state.is_null() {
+        drop(unsafe { Box::from_raw(state) });
+    }
+}
+
+fn with_state_mut<R>(
+    state: *mut MwState,
+    f: impl FnOnce(&mut MajestikCore) -> R,
+) -> Result<R, MwResult> {
+    unsafe { state.as_mut() }
+        .map(|mw_state| Ok(f(&mut mw_state.inner)))
+        .unwrap_or_else(|| Err(MwResult::NullPointer))
+}
+
+fn with_state<R>(state: *const MwState, f: impl FnOnce(&MajestikCore) -> R) -> Result<R, MwResult> {
+    unsafe { state.as_ref() }
+        .map(|mw_state| Ok(f(&mw_state.inner)))
+        .unwrap_or_else(|| Err(MwResult::NullPointer))
+}
+
+/// Advance the simulation by `dt_seconds` seconds.
+///
+/// # Safety
+/// `state` must be a pointer previously returned by [`mw_core_create`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mw_core_tick(
+    state: *mut MwState,
+    dt_seconds: f32,
+    update_terrain: MwBool,
+) -> MwResult {
+    if !dt_seconds.is_finite() || dt_seconds < 0.0 {
+        return MwResult::InvalidDeltaTime;
+    }
+
+    with_state_mut(state, |core| {
+        let config = TickConfig {
+            update_terrain: update_terrain != 0,
+        };
+        core.tick(Duration::from_secs_f32(dt_seconds), config);
+    })
+    .map(|_| MwResult::Success)
+    .unwrap_or_else(|err| err)
+}
+
+fn write_scalar<T: Copy>(out: *mut T, value: T) -> MwResult {
+    if let Some(slot) = unsafe { out.as_mut() } {
+        *slot = value;
+        MwResult::Success
+    } else {
+        MwResult::NullPointer
+    }
+}
+
+fn terrain_diff_into_mw(diff: TerrainDiff) -> MwTerrainDiff {
+    fn convert(chunks: Vec<TerrainChunkCoord>) -> MwTerrainChunkBuffer {
+        let coords = chunks.into_iter().map(MwTerrainChunkCoord::from).collect();
+        MwTerrainChunkBuffer::from_vec(coords)
+    }
+
+    MwTerrainDiff {
+        new_chunks: convert(diff.new_chunks),
+        modified_chunks: convert(diff.modified_chunks),
+        removed_chunks: convert(diff.removed_chunks),
+    }
+}
+
+/// Query the accumulated simulation time in seconds.
+///
+/// # Safety
+/// `state` must be a valid pointer returned by [`mw_core_create`], `out_time`
+/// must be writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mw_core_time_seconds(
+    state: *const MwState,
+    out_time: *mut f64,
+) -> MwResult {
+    with_state(state, MajestikCore::time_seconds)
+        .map(|time| write_scalar(out_time, time))
+        .unwrap_or_else(|err| err)
+}
+
+/// Query the accumulated program time in seconds.
+///
+/// # Safety
+/// `state` must be a valid pointer returned by [`mw_core_create`], `out_time`
+/// must be writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mw_core_program_time_seconds(
+    state: *const MwState,
+    out_time: *mut f64,
+) -> MwResult {
+    with_state(state, MajestikCore::program_time_seconds)
+        .map(|time| write_scalar(out_time, time))
+        .unwrap_or_else(|err| err)
+}
+
+/// Query the accumulated in-game time-of-day in seconds.
+///
+/// # Safety
+/// `state` must be a valid pointer returned by [`mw_core_create`], `out_time`
+/// must be writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mw_core_time_of_day_seconds(
+    state: *const MwState,
+    out_time: *mut f64,
+) -> MwResult {
+    with_state(state, MajestikCore::time_of_day_seconds)
+        .map(|time| write_scalar(out_time, time))
+        .unwrap_or_else(|err| err)
+}
+
+/// Fetch the [`MwGameMode`] currently running inside the state handle.
+///
+/// # Safety
+/// `state` must be a valid pointer returned by [`mw_core_create`], `out_mode`
+/// must be writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mw_core_game_mode(
+    state: *const MwState,
+    out_mode: *mut MwGameMode,
+) -> MwResult {
+    with_state(state, MajestikCore::game_mode)
+        .map(MwGameMode::from)
+        .map(|mode| write_scalar(out_mode, mode))
+        .unwrap_or_else(|err| err)
+}
+
+/// Consume and return the terrain diff captured during the previous tick.
+///
+/// # Safety
+/// `state` and `out_diff` must be valid pointers. The caller is responsible for
+/// releasing buffers contained in `MwTerrainDiff` via
+/// [`mw_terrain_chunk_buffer_free`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mw_core_last_terrain_diff_take(
+    state: *mut MwState,
+    out_diff: *mut MwTerrainDiff,
+) -> MwResult {
+    if out_diff.is_null() {
+        return MwResult::NullPointer;
+    }
+
+    with_state_mut(state, |core| core.take_last_terrain_diff())
+        .map(terrain_diff_into_mw)
+        .map(|diff| {
+            unsafe { *out_diff = diff };
+            MwResult::Success
+        })
+        .unwrap_or_else(|err| err)
+}
+
+/// Release memory owned by a terrain chunk buffer previously returned from
+/// [`mw_core_last_terrain_diff_take`].
+///
+/// # Safety
+/// `buffer` must either be null or point to a valid buffer that has not yet
+/// been freed.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn mw_terrain_chunk_buffer_free(buffer: *mut MwTerrainChunkBuffer) {
+    if let Some(buf) = unsafe { buffer.as_mut() } {
+        if !buf.ptr.is_null() && buf.len > 0 {
+            // SAFETY: The pointer/length pair was produced by `from_vec`, so
+            // it is safe to reconstruct the boxed slice.
+            let slice = std::ptr::slice_from_raw_parts_mut(buf.ptr, buf.len);
+            drop(unsafe { Box::from_raw(slice) });
+        }
+        buf.ptr = std::ptr::null_mut();
+        buf.len = 0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ptr;
+
+    #[test]
+    fn create_tick_and_destroy_round_trip() {
+        let mut handle: *mut MwState = ptr::null_mut();
+        let config = MwCoreConfig::default();
+        assert_eq!(
+            unsafe { mw_core_create(&config, &mut handle) },
+            MwResult::Success
+        );
+        assert!(!handle.is_null());
+
+        assert_eq!(unsafe { mw_core_tick(handle, 0.016, 0) }, MwResult::Success);
+
+        let mut time = 0.0;
+        assert_eq!(
+            unsafe { mw_core_time_seconds(handle, &mut time) },
+            MwResult::Success
+        );
+        assert!(time > 0.0);
+
+        unsafe { mw_core_destroy(handle) };
+    }
+
+    #[test]
+    fn rejects_invalid_delta_time() {
+        let mut handle: *mut MwState = ptr::null_mut();
+        assert_eq!(
+            unsafe { mw_core_create(ptr::null(), &mut handle) },
+            MwResult::Success
+        );
+        assert_eq!(
+            unsafe { mw_core_tick(handle, f32::NAN, 0) },
+            MwResult::InvalidDeltaTime
+        );
+        unsafe { mw_core_destroy(handle) };
+    }
+
+    #[test]
+    fn terrain_diff_take_returns_empty_by_default() {
+        let mut handle: *mut MwState = ptr::null_mut();
+        assert_eq!(
+            unsafe { mw_core_create(ptr::null(), &mut handle) },
+            MwResult::Success
+        );
+
+        let mut diff = MwTerrainDiff::default();
+        assert_eq!(
+            unsafe { mw_core_last_terrain_diff_take(handle, &mut diff) },
+            MwResult::Success
+        );
+        assert_eq!(diff.new_chunks.len, 0);
+        assert!(diff.new_chunks.ptr.is_null());
+
+        unsafe {
+            mw_terrain_chunk_buffer_free(&mut diff.new_chunks);
+            mw_terrain_chunk_buffer_free(&mut diff.modified_chunks);
+            mw_terrain_chunk_buffer_free(&mut diff.removed_chunks);
+            mw_core_destroy(handle);
+        }
+    }
+
+    #[test]
+    fn terrain_diff_conversion_allocates_buffers() {
+        let diff = TerrainDiff {
+            new_chunks: vec![TerrainChunkCoord::new(1, 2)],
+            modified_chunks: vec![TerrainChunkCoord::new(-4, 3)],
+            removed_chunks: vec![],
+        };
+
+        let mut ffi_diff = terrain_diff_into_mw(diff);
+        unsafe {
+            let new_chunks =
+                std::slice::from_raw_parts(ffi_diff.new_chunks.ptr, ffi_diff.new_chunks.len);
+            assert_eq!(new_chunks, &[MwTerrainChunkCoord { x: 1, y: 2 }],);
+
+            let modified_chunks = std::slice::from_raw_parts(
+                ffi_diff.modified_chunks.ptr,
+                ffi_diff.modified_chunks.len,
+            );
+            assert_eq!(modified_chunks, &[MwTerrainChunkCoord { x: -4, y: 3 }],);
+
+            mw_terrain_chunk_buffer_free(&mut ffi_diff.new_chunks);
+            mw_terrain_chunk_buffer_free(&mut ffi_diff.modified_chunks);
+            mw_terrain_chunk_buffer_free(&mut ffi_diff.removed_chunks);
+        }
+    }
+}

--- a/rust/unreal-bindings/src/lib.rs
+++ b/rust/unreal-bindings/src/lib.rs
@@ -3,6 +3,10 @@
 //! The exported functions provide the `init/tick/shutdown` loop described in
 //! `UE5_PLUGIN_MASTER_PLAN.md` Phase 2 and `docs/ue5_plugin_migration_plan.md`
 //! §7, enabling Unreal Engine prototypes to call into the Rust simulation.
+//!
+//! For licensing or redistribution questions related to this FFI surface,
+//! contact GitHub user `beyawnko`, who retains sole ownership during the UE5
+//! migration effort.
 
 use std::{
     collections::HashMap,

--- a/rust/unreal-bindings/src/lib.rs
+++ b/rust/unreal-bindings/src/lib.rs
@@ -1,3 +1,6 @@
+// `unsafe(no_mangle)` became stable in Rust 1.82. We still enable the
+// historical feature gate when the build script detects a nightly/dev
+// compiler so older toolchains keep compiling without warnings.
 #![cfg_attr(ffi_use_unsafe_attributes, allow(stable_features))]
 #![cfg_attr(ffi_use_unsafe_attributes, feature(unsafe_attributes))]
 


### PR DESCRIPTION
## Summary
- capture chunk-level terrain diffs inside `majestic-world-core` each tick so the UE bridge can stream updates without touching internal ECS resources (UE5 migration plan §5)
- extend `majestic-world-ffi` with `mw_core_last_terrain_diff_take` and buffer free helpers that marshal those diffs into UE-friendly arrays, including unit tests
- document the new data contract in `docs/ue5_plugin_migration_plan.md` and explain the workflow in `rust/README.md`

## Testing
- cargo fmt
- cargo test -p majestic-world-core
- cargo test -p majestic-world-ffi


------
https://chatgpt.com/codex/tasks/task_e_68cfb71e3a8883228819c57e3f410e39