### PR TITLE
fix: harden UE5 FFI build script and header generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4012,6 +4012,7 @@ version = "0.1.0"
 dependencies = [
  "cbindgen",
  "majestic-world-core",
+ "proptest",
 ]
 
 [[package]]
@@ -4397,7 +4398,7 @@ checksum = "6da45c8333f2e152fc665d78a380be060eb84fad8ca4c9f7ac8ca29216cff0cc"
 dependencies = [
  "num-traits",
  "rand 0.8.5",
- "rand_xorshift",
+ "rand_xorshift 0.3.0",
 ]
 
 [[package]]
@@ -5511,6 +5512,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bb0be07becd10686a0bb407298fb425360a5c44a663774406340c59a22de4ce"
+dependencies = [
+ "bitflags 2.9.4",
+ "lazy_static",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift 0.4.0",
+ "regex-syntax 0.8.6",
+ "unarray",
+]
+
+[[package]]
 name = "protocol"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5746,6 +5763,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -7716,6 +7742,12 @@ name = "ubyte"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f720def6ce1ee2fc44d40ac9ed6d3a59c361c80a75a7aa8e75bb9baed31cf2ea"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unic-langid"

--- a/rust/unreal-bindings/Cargo.toml
+++ b/rust/unreal-bindings/Cargo.toml
@@ -16,7 +16,7 @@ majestic-world-core = { path = "../core" }
 
 [dev-dependencies]
 majestic-world-core = { path = "../core", features = ["test-only-unsafe-hooks"] }
-proptest = { version = "1.4", default-features = false, features = ["std"] }
+proptest = { version = "1.8.0", default-features = false, features = ["std"] }
 
 [build-dependencies]
 cbindgen = "^0.27.0"

--- a/rust/unreal-bindings/Cargo.toml
+++ b/rust/unreal-bindings/Cargo.toml
@@ -19,3 +19,4 @@ majestic-world-core = { path = "../core", features = ["test-only-unsafe-hooks"] 
 
 [build-dependencies]
 cbindgen = "^0.27.0"
+proptest = { version = "1.4", default-features = false, features = ["std"] }

--- a/rust/unreal-bindings/Cargo.toml
+++ b/rust/unreal-bindings/Cargo.toml
@@ -16,7 +16,7 @@ majestic-world-core = { path = "../core" }
 
 [dev-dependencies]
 majestic-world-core = { path = "../core", features = ["test-only-unsafe-hooks"] }
+proptest = { version = "1.4", default-features = false, features = ["std"] }
 
 [build-dependencies]
 cbindgen = "^0.27.0"
-proptest = { version = "1.4", default-features = false, features = ["std"] }

--- a/rust/unreal-bindings/build.rs
+++ b/rust/unreal-bindings/build.rs
@@ -3,7 +3,7 @@ use std::{
     error::Error,
     fs,
     io::{Error as IoError, ErrorKind},
-    path::{Component, Path, PathBuf},
+    path::{Path, PathBuf},
 };
 
 use cbindgen::{Builder, Config, DocumentationLength, Language};
@@ -94,200 +94,226 @@ fn get_header_filename() -> String {
     }
 }
 
-fn decode_hex_digit(byte: u8) -> Option<u8> {
-    match byte {
-        b'0'..=b'9' => Some(byte - b'0'),
-        b'a'..=b'f' => Some(byte - b'a' + 10),
-        b'A'..=b'F' => Some(byte - b'A' + 10),
-        _ => None,
+/// Security-oriented helpers that validate toolchain execution paths before
+/// invoking `rustc`.
+mod security {
+    use std::{
+        fs,
+        path::{Component, Path, PathBuf},
+    };
+
+    use super::RUSTC_PATH_LENGTH_LIMIT;
+
+    fn decode_hex_digit(byte: u8) -> Option<u8> {
+        match byte {
+            b'0'..=b'9' => Some(byte - b'0'),
+            b'a'..=b'f' => Some(byte - b'a' + 10),
+            b'A'..=b'F' => Some(byte - b'A' + 10),
+            _ => None,
+        }
     }
-}
 
-fn contains_forbidden_percent_encoding(value: &str) -> bool {
-    let bytes = value.as_bytes();
-    let mut index = 0;
+    fn contains_forbidden_percent_encoding(value: &str) -> bool {
+        let bytes = value.as_bytes();
+        let mut index = 0;
 
-    while index < bytes.len() {
-        if bytes[index] != b'%' {
-            index += 1;
-            continue;
+        while index < bytes.len() {
+            if bytes[index] != b'%' {
+                index += 1;
+                continue;
+            }
+
+            let remaining = bytes.len() - index;
+            if remaining <= 2 {
+                return true;
+            }
+
+            let high = match bytes.get(index + 1).copied().and_then(decode_hex_digit) {
+                Some(value) => value,
+                None => return true,
+            };
+            let low = match bytes.get(index + 2).copied().and_then(decode_hex_digit) {
+                Some(value) => value,
+                None => return true,
+            };
+            let decoded = (high << 4) | low;
+
+            match decoded {
+                b'.' | b'/' | b'\\' | b' ' | b'\t' | b'\n' | b'\r' => return true,
+                _ => {},
+            }
+
+            index += 3;
         }
 
-        let high = match bytes.get(index + 1).copied().and_then(decode_hex_digit) {
-            Some(value) => value,
-            None => return true,
-        };
-        let low = match bytes.get(index + 2).copied().and_then(decode_hex_digit) {
-            Some(value) => value,
-            None => return true,
-        };
-        let decoded = (high << 4) | low;
-
-        match decoded {
-            b'.' | b'/' | b'\\' | b' ' | b'\t' | b'\n' | b'\r' => return true,
-            _ => {},
-        }
-
-        index += 3;
-    }
-
-    false
-}
-
-fn is_allowed_compiler_name(value: &str) -> bool {
-    let lower = value.to_ascii_lowercase();
-
-    matches!(
-        lower.as_str(),
-        "rustc"
-            | "rustc.exe"
-            | "rustc.bat"
-            | "rustc.cmd"
-            | "rustc_driver"
-            | "rustc_driver.exe"
-            | "rustc-wrapper"
-            | "rustc-wrapper.exe"
-            | "sccache"
-            | "sccache.exe"
-            | "ccache"
-            | "ccache.exe"
-    ) || lower.starts_with("rustc-")
-        || lower.starts_with("rustc_")
-}
-
-// NOTE: We validate both the raw path string and (when possible) the
-// canonicalised filesystem location to defend against obvious traversal
-// attacks (including symlink chains) while still delegating race-condition
-// handling to the actual `rustc` invocation. On Windows/UNC paths we fall back
-// to validating the raw components if canonicalisation is not available.
-fn rustc_path_is_safe(rustc: &str) -> bool {
-    if rustc.is_empty() || rustc.len() >= RUSTC_PATH_LENGTH_LIMIT {
-        return false;
-    }
-
-    // Reject shell metacharacters while allowing Windows path separators.
-    if rustc.chars().any(|ch| {
-        matches!(
-            ch,
-            ';' | '&'
-                | '|'
-                | '`'
-                | '$'
-                | '>'
-                | '<'
-                | '\n'
-                | '\r'
-                | '\0'
-                | '\t'
-                | '"'
-                | '\''
-                | '*'
-                | '?'
-                | '['
-                | ']'
-                | '{'
-                | '}'
-                | '('
-                | ')'
-                | '~'
-                | '#'
-                | '!'
-                | '^'
-                | ' '
-        )
-    }) {
-        return false;
-    }
-
-    if rustc.contains("..") || contains_forbidden_percent_encoding(rustc) {
-        return false;
-    }
-
-    if rustc.starts_with('-') {
-        return false;
-    }
-
-    let path = Path::new(rustc);
-    if path
-        .components()
-        .any(|component| matches!(component, Component::ParentDir | Component::CurDir))
-    {
-        return false;
-    }
-
-    let is_simple = !rustc.contains('/') && !rustc.contains('\\');
-    let bytes = rustc.as_bytes();
-    let is_absolute_unix = rustc.starts_with('/');
-    let is_absolute_windows = bytes.len() >= 3
-        && bytes[0].is_ascii_alphabetic()
-        && bytes[1] == b':'
-        && matches!(bytes[2], b'/' | b'\\');
-    let is_unc = if bytes.len() >= 5 && bytes[0] == b'\\' && bytes[1] == b'\\' {
-        let third = bytes[2];
-        third != b'\\' && third != b'/' && bytes[2..].contains(&b'\\')
-    } else {
         false
-    };
-
-    if !(is_simple || is_absolute_unix || is_absolute_windows || is_unc) {
-        return false;
     }
 
-    if is_simple && rustc.contains(':') {
-        return false;
+    fn is_allowed_compiler_name(value: &str) -> bool {
+        let lower = value.to_ascii_lowercase();
+
+        matches!(
+            lower.as_str(),
+            "rustc"
+                | "rustc.exe"
+                | "rustc.bat"
+                | "rustc.cmd"
+                | "rustc_driver"
+                | "rustc_driver.exe"
+                | "rustc-wrapper"
+                | "rustc-wrapper.exe"
+                | "sccache"
+                | "sccache.exe"
+                | "ccache"
+                | "ccache.exe"
+        ) || lower.starts_with("rustc-")
+            || lower.starts_with("rustc_")
     }
 
-    if is_simple {
-        return is_allowed_compiler_name(rustc);
-    }
-
-    let inspected_path = match fs::canonicalize(path) {
-        Ok(path) => path,
-        Err(_) if is_absolute_windows || is_unc => PathBuf::from(rustc),
-        Err(_) => return false,
-    };
-
-    if let Some(parent) = inspected_path.parent() {
-        let parent_lower = parent.to_string_lossy().to_ascii_lowercase();
-        const ALLOWED_PREFIXES: &[&str] = &[
-            "/usr/bin",
-            "/usr/local/bin",
-            "/opt/",
-            "c:/rust",
-            "c:/program files",
-            "c:/users",
-            "c:\\rust",
-            "c:\\program files",
-            "c:\\users",
-        ];
-
-        let allowed = parent_lower.starts_with("\\\\")
-            || ALLOWED_PREFIXES
-                .iter()
-                .any(|prefix| parent_lower.starts_with(prefix))
-            || parent_lower.contains("/.cargo/bin")
-            || parent_lower.contains("\\.cargo\\bin")
-            || parent_lower.contains("/.rustup/toolchains")
-            || parent_lower.contains("\\.rustup\\toolchains")
-            || parent_lower.contains("program files");
-
-        if !allowed {
+    /// Evaluate whether a provided `rustc` executable path is considered safe
+    /// to execute.
+    ///
+    /// The validator aggressively rejects obvious command-injection vectors,
+    /// percent-encoded traversal attempts, and canonicalised paths that escape
+    /// a curated allowlist of toolchain directories. Canonicalisation is
+    /// only used to reduce symlink and traversal risks; the build
+    /// immediately hands off to Cargo after validation to avoid extending
+    /// the TOCTOU window.
+    pub(crate) fn rustc_path_is_safe(rustc: &str) -> bool {
+        if rustc.is_empty() || rustc.len() >= RUSTC_PATH_LENGTH_LIMIT {
             return false;
         }
+
+        if rustc.chars().any(|ch| {
+            matches!(
+                ch,
+                ';' | '&'
+                    | '|'
+                    | '`'
+                    | '$'
+                    | '>'
+                    | '<'
+                    | '\n'
+                    | '\r'
+                    | '\0'
+                    | '\t'
+                    | '"'
+                    | '\''
+                    | '*'
+                    | '?'
+                    | '['
+                    | ']'
+                    | '{'
+                    | '}'
+                    | '('
+                    | ')'
+                    | '~'
+                    | '#'
+                    | '!'
+                    | '^'
+                    | ' '
+            )
+        }) {
+            return false;
+        }
+
+        if rustc.contains("..") || contains_forbidden_percent_encoding(rustc) {
+            return false;
+        }
+
+        if rustc.starts_with('-') {
+            return false;
+        }
+
+        let path = Path::new(rustc);
+        if path
+            .components()
+            .any(|component| matches!(component, Component::ParentDir | Component::CurDir))
+        {
+            return false;
+        }
+
+        let is_simple = !rustc.contains('/') && !rustc.contains('\\');
+        let bytes = rustc.as_bytes();
+        let is_absolute_unix = rustc.starts_with('/');
+        let is_absolute_windows = bytes.len() >= 3
+            && bytes[0].is_ascii_alphabetic()
+            && bytes[1] == b':'
+            && matches!(bytes[2], b'/' | b'\\');
+        let is_unc = if bytes.len() >= 5 && bytes[0] == b'\\' && bytes[1] == b'\\' {
+            let third = bytes[2];
+            third != b'\\' && third != b'/' && bytes[2..].contains(&b'\\')
+        } else {
+            false
+        };
+
+        if !(is_simple || is_absolute_unix || is_absolute_windows || is_unc) {
+            return false;
+        }
+
+        if is_simple && rustc.contains(':') {
+            return false;
+        }
+
+        if is_simple {
+            return is_allowed_compiler_name(rustc);
+        }
+
+        let inspected_path = match fs::canonicalize(path) {
+            Ok(path) => path,
+            Err(_) if is_absolute_windows || is_unc => PathBuf::from(rustc),
+            Err(_) => return false,
+        };
+
+        if let Some(parent) = inspected_path.parent() {
+            let parent_lower = parent.to_string_lossy().to_ascii_lowercase();
+            const ALLOWED_PREFIXES: &[&str] = &[
+                "/usr/bin",
+                "/usr/local/bin",
+                "/opt/",
+                "c:/rust",
+                "c:/program files",
+                "c:/users",
+                "c\\rust",
+                "c\\program files",
+                "c\\users",
+            ];
+
+            let allowed = parent_lower.starts_with("\\\\")
+                || ALLOWED_PREFIXES
+                    .iter()
+                    .any(|prefix| parent_lower.starts_with(prefix))
+                || parent_lower.contains("/.cargo/bin")
+                || parent_lower.contains("\\.cargo\\bin")
+                || parent_lower.contains("/.rustup/toolchains")
+                || parent_lower.contains("\\.rustup\\toolchains")
+                || parent_lower.contains("program files");
+
+            if !allowed {
+                return false;
+            }
+        }
+
+        let file_name = inspected_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(|name| name.to_ascii_lowercase());
+
+        match file_name.as_deref() {
+            Some(name) if is_allowed_compiler_name(name) => {},
+            _ => return false,
+        }
+
+        true
     }
 
-    let file_name = inspected_path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .map(|name| name.to_ascii_lowercase());
-
-    match file_name.as_deref() {
-        Some(name) if is_allowed_compiler_name(name) => {},
-        _ => return false,
+    #[cfg(test)]
+    pub(super) fn contains_forbidden_percent_encoding_public(value: &str) -> bool {
+        contains_forbidden_percent_encoding(value)
     }
-
-    true
 }
+
+pub(crate) use security::rustc_path_is_safe;
 
 fn main() {
     let rustc = env::var("RUSTC").unwrap_or_else(|_| "rustc".to_string());
@@ -530,7 +556,7 @@ fn try_write_repository_header(
 mod tests {
     use super::{
         HEADER_FILENAME, RUSTC_PATH_LENGTH_LIMIT, build_config, get_header_filename,
-        rustc_path_is_safe, write_if_changed,
+        rustc_path_is_safe, security, write_if_changed,
     };
     use std::{
         env, fs,
@@ -538,6 +564,22 @@ mod tests {
         path::PathBuf,
         time::{SystemTime, UNIX_EPOCH},
     };
+
+    use proptest::prelude::*;
+
+    const FORBIDDEN_SHELL_CHARS: &[char] = &[
+        ';', '&', '|', '`', '$', '>', '<', '\n', '\r', '\0', '\t', '"', '\'', '*', '?', '[', ']',
+        '{', '}', '(', ')', '~', '#', '!', '^', ' ',
+    ];
+
+    const ALLOWED_WRAPPER_NAMES: &[&str] =
+        &["rustc", "rustc.exe", "rustc-wrapper", "sccache", "ccache"];
+
+    const NON_HEX_CHARS: &[char] = &['g', 'G', 'z', 'Z', '/', ':', '-', '_'];
+    const SAFE_HEX_DIGITS: &[char] = &[
+        '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', 'A', 'B',
+        'C', 'D', 'E', 'F',
+    ];
 
     fn unique_temp_dir(prefix: &str) -> PathBuf {
         let timestamp = SystemTime::now()
@@ -567,11 +609,26 @@ mod tests {
             assert!(!rustc_path_is_safe("rustc|malicious"));
         }
 
+        proptest! {
+            #[test]
+            fn rejects_forbidden_shell_chars(ch in prop::sample::select(FORBIDDEN_SHELL_CHARS.to_vec())) {
+                let candidate = format!("rustc{ch}payload");
+                prop_assert!(!rustc_path_is_safe(&candidate));
+            }
+        }
+
         #[test]
         fn allows_common_wrappers() {
             assert!(rustc_path_is_safe("/usr/bin/sccache"));
             assert!(rustc_path_is_safe("/usr/local/bin/rustc-wrapper"));
             assert!(rustc_path_is_safe("ccache"));
+        }
+
+        proptest! {
+            #[test]
+            fn allows_known_wrapper_names(wrapper in prop::sample::select(ALLOWED_WRAPPER_NAMES.to_vec())) {
+                prop_assert!(rustc_path_is_safe(wrapper));
+            }
         }
 
         #[test]
@@ -617,6 +674,25 @@ mod tests {
         }
 
         #[test]
+        fn rejects_incomplete_percent_at_end() {
+            assert!(security::contains_forbidden_percent_encoding_public("%"));
+            assert!(security::contains_forbidden_percent_encoding_public(
+                "rustc%"
+            ));
+            assert!(security::contains_forbidden_percent_encoding_public(
+                "rustc%2"
+            ));
+        }
+
+        proptest! {
+            #[test]
+            fn rejects_non_hex_percent_sequences(high in prop::sample::select(NON_HEX_CHARS.to_vec()), low in prop::sample::select(NON_HEX_CHARS.to_vec())) {
+                let candidate = format!("%{high}{low}");
+                prop_assert!(security::contains_forbidden_percent_encoding_public(&candidate));
+            }
+        }
+
+        #[test]
         fn allows_harmless_percent_sequences() {
             let base = unique_temp_dir("mw_percent_test");
             let cargo_bin = base.join(".cargo/bin");
@@ -631,6 +707,22 @@ mod tests {
                 .expect("path not valid UTF-8")
                 .to_string();
             assert!(rustc_path_is_safe(&tool_str));
+        }
+
+        proptest! {
+            #[test]
+            fn allows_safe_percent_sequences(
+                high in prop::sample::select(SAFE_HEX_DIGITS.to_vec()),
+                low in prop::sample::select(SAFE_HEX_DIGITS.to_vec()),
+            ) {
+                let pair = format!("{high}{low}");
+                if let Ok(decoded) = u8::from_str_radix(&pair, 16) {
+                    prop_assume!(!matches!(decoded, b'.' | b'/' | b'\\' | b' ' | b'\t' | b'\n' | b'\r'));
+
+                    let candidate = format!("/usr/local/bin/rustc%{pair}");
+                    prop_assert!(rustc_path_is_safe(&candidate));
+                }
+            }
         }
 
         #[cfg(unix)]

--- a/rust/unreal-bindings/build.rs
+++ b/rust/unreal-bindings/build.rs
@@ -113,15 +113,11 @@ fn contains_forbidden_percent_encoding(value: &str) -> bool {
             continue;
         }
 
-        if index + 2 >= bytes.len() {
-            return true;
-        }
-
-        let high = match decode_hex_digit(bytes[index + 1]) {
+        let high = match bytes.get(index + 1).copied().and_then(decode_hex_digit) {
             Some(value) => value,
             None => return true,
         };
-        let low = match decode_hex_digit(bytes[index + 2]) {
+        let low = match bytes.get(index + 2).copied().and_then(decode_hex_digit) {
             Some(value) => value,
             None => return true,
         };
@@ -251,6 +247,35 @@ fn rustc_path_is_safe(rustc: &str) -> bool {
         Err(_) => return false,
     };
 
+    if let Some(parent) = inspected_path.parent() {
+        let parent_lower = parent.to_string_lossy().to_ascii_lowercase();
+        const ALLOWED_PREFIXES: &[&str] = &[
+            "/usr/bin",
+            "/usr/local/bin",
+            "/opt/",
+            "c:/rust",
+            "c:/program files",
+            "c:/users",
+            "c:\\rust",
+            "c:\\program files",
+            "c:\\users",
+        ];
+
+        let allowed = parent_lower.starts_with("\\\\")
+            || ALLOWED_PREFIXES
+                .iter()
+                .any(|prefix| parent_lower.starts_with(prefix))
+            || parent_lower.contains("/.cargo/bin")
+            || parent_lower.contains("\\.cargo\\bin")
+            || parent_lower.contains("/.rustup/toolchains")
+            || parent_lower.contains("\\.rustup\\toolchains")
+            || parent_lower.contains("program files");
+
+        if !allowed {
+            return false;
+        }
+    }
+
     let file_name = inspected_path
         .file_name()
         .and_then(|name| name.to_str())
@@ -278,6 +303,8 @@ fn main() {
 fn build_config(header_preamble: &str) -> Config {
     Config {
         language: Language::C,
+        // Prefer `#pragma once` to avoid guard name collisions across generated
+        // headers while keeping include protection consistent across toolchains.
         pragma_once: true,
         include_guard: None,
         cpp_compat: true,
@@ -509,7 +536,16 @@ mod tests {
         env, fs,
         io::{Error as IoError, ErrorKind},
         path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
     };
+
+    fn unique_temp_dir(prefix: &str) -> PathBuf {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        env::temp_dir().join(format!("{prefix}_{:x}_{:x}", std::process::id(), timestamp))
+    }
 
     mod rustc_path_validation {
         use super::*;
@@ -577,6 +613,24 @@ mod tests {
             assert!(!rustc_path_is_safe("rustc%"));
             assert!(!rustc_path_is_safe("rustc%2"));
             assert!(!rustc_path_is_safe("rustc%2G"));
+            assert!(!rustc_path_is_safe("%"));
+        }
+
+        #[test]
+        fn allows_harmless_percent_sequences() {
+            let base = unique_temp_dir("mw_percent_test");
+            let cargo_bin = base.join(".cargo/bin");
+            fs::create_dir_all(&cargo_bin).expect("failed to create cargo bin directory");
+            let _guard = super::file_operations::TempDirGuard(base.clone());
+
+            let tool_path = cargo_bin.join("rustc%41");
+            fs::write(&tool_path, b"#!/bin/true\n").expect("failed to create dummy compiler");
+
+            let tool_str = tool_path
+                .to_str()
+                .expect("path not valid UTF-8")
+                .to_string();
+            assert!(rustc_path_is_safe(&tool_str));
         }
 
         #[cfg(unix)]
@@ -584,8 +638,7 @@ mod tests {
         fn rejects_symlink_pointing_to_unexpected_binary() {
             use std::os::unix::fs::symlink;
 
-            let temp_dir =
-                std::env::temp_dir().join(format!("mw_build_symlink_test_{}", std::process::id()));
+            let temp_dir = unique_temp_dir("mw_build_symlink_test");
             let _ = fs::remove_dir_all(&temp_dir);
             fs::create_dir_all(&temp_dir).expect("failed to create symlink test dir");
             let _guard = super::file_operations::TempDirGuard(temp_dir.clone());
@@ -646,6 +699,34 @@ mod tests {
         #[test]
         fn rejects_suspicious_canonical_paths() {
             assert!(!rustc_path_is_safe("/tmp/../../../bin/sh"));
+        }
+
+        #[test]
+        fn enforces_directory_allowlist() {
+            let allowed_root = unique_temp_dir("mw_allowlist_ok");
+            let allowed_bin = allowed_root.join(".cargo/bin");
+            fs::create_dir_all(&allowed_bin).expect("failed to create allowed bin directory");
+            let allowed_guard = super::file_operations::TempDirGuard(allowed_root.clone());
+            let allowed_path = allowed_bin.join("rustc");
+            fs::write(&allowed_path, b"#!/bin/true\n").expect("failed to create allowed tool");
+            let allowed_str = allowed_path
+                .to_str()
+                .expect("allowed path not UTF-8")
+                .to_string();
+            assert!(rustc_path_is_safe(&allowed_str));
+            drop(allowed_guard);
+
+            let disallowed_root = unique_temp_dir("mw_allowlist_blocked");
+            fs::create_dir_all(&disallowed_root).expect("failed to create disallowed dir");
+            let _disallowed_guard = super::file_operations::TempDirGuard(disallowed_root.clone());
+            let disallowed_path = disallowed_root.join("rustc");
+            fs::write(&disallowed_path, b"#!/bin/true\n")
+                .expect("failed to create disallowed tool");
+            let disallowed_str = disallowed_path
+                .to_str()
+                .expect("disallowed path not UTF-8")
+                .to_string();
+            assert!(!rustc_path_is_safe(&disallowed_str));
         }
     }
 

--- a/rust/unreal-bindings/build.rs
+++ b/rust/unreal-bindings/build.rs
@@ -84,6 +84,14 @@ impl SafeRustcPath {
     pub fn as_path(&self) -> &Path { &self.0 }
 }
 
+impl AsRef<Path> for SafeRustcPath {
+    fn as_ref(&self) -> &Path { self.as_path() }
+}
+
+impl From<SafeRustcPath> for PathBuf {
+    fn from(value: SafeRustcPath) -> Self { value.0 }
+}
+
 fn get_header_filename() -> String {
     const ENV_KEY: &str = "MW_FFI_HEADER_NAME";
     match env::var(ENV_KEY) {

--- a/rust/unreal-bindings/build.rs
+++ b/rust/unreal-bindings/build.rs
@@ -9,6 +9,7 @@ use std::{
 use cbindgen::{Builder, Config, DocumentationLength, Language};
 
 const HEADER_FILENAME: &str = "majestic_world_ffi.h";
+const RUSTC_PATH_LENGTH_LIMIT: usize = 4_096;
 const HEADER_PREAMBLE_TEMPLATE: &str = r#"/*
  * Majestic World FFI (auto-generated).
  *
@@ -164,7 +165,7 @@ fn is_allowed_compiler_name(value: &str) -> bool {
 // handling to the actual `rustc` invocation. On Windows/UNC paths we fall back
 // to validating the raw components if canonicalisation is not available.
 fn rustc_path_is_safe(rustc: &str) -> bool {
-    if rustc.is_empty() || rustc.len() >= 4_096 {
+    if rustc.is_empty() || rustc.len() >= RUSTC_PATH_LENGTH_LIMIT {
         return false;
     }
 
@@ -292,6 +293,7 @@ fn build_config(header_preamble: &str) -> Config {
     }
 }
 
+/// Emit fine-grained Cargo rebuild directives for the crate and its sources.
 fn emit_rerun_directives(crate_dir: &Path) -> Result<(), Box<dyn Error>> {
     let build_script = crate_dir.join("build.rs");
     println!("cargo:rerun-if-changed={}", build_script.display());
@@ -304,6 +306,7 @@ fn emit_rerun_directives(crate_dir: &Path) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+/// Recursively register all Rust source files under `src_dir` for rebuilds.
 fn emit_rerun_for_sources(src_dir: &Path) -> Result<(), Box<dyn Error>> {
     if !src_dir.exists() {
         return Ok(());
@@ -332,6 +335,12 @@ fn emit_rerun_for_sources(src_dir: &Path) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+/// Generate the C header via cbindgen, mirroring it into the repository if
+/// possible.
+///
+/// The function ensures cargo rebuild directives are accurate, validates the
+/// generated output is non-empty, and surfaces actionable errors when the
+/// generation pipeline fails at any step.
 fn generate_header() -> Result<(), Box<dyn Error>> {
     let crate_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?);
     emit_rerun_directives(&crate_dir)?;
@@ -367,7 +376,10 @@ fn generate_header() -> Result<(), Box<dyn Error>> {
         .map_err(|err| -> Box<dyn Error> {
             Box::new(IoError::new(
                 ErrorKind::Other,
-                format!("cbindgen failed to generate bindings: {err}"),
+                format!(
+                    "failed to generate bindings with cbindgen for {}: {err}",
+                    crate_dir.display()
+                ),
             ))
         })?;
 
@@ -376,18 +388,22 @@ fn generate_header() -> Result<(), Box<dyn Error>> {
 
     if new_file_bytes.is_empty() {
         return Err(IoError::new(
-            ErrorKind::Other,
-            "cbindgen produced an empty header; ensure FFI exports are marked #[no_mangle] and \
-             declared extern \"C\"",
+            ErrorKind::InvalidData,
+            format!(
+                "cbindgen produced an empty header for {header_filename}; ensure FFI exports are \
+                 marked #[no_mangle] and declared extern \"C\"",
+            ),
         )
         .into());
     }
     let new_contents = String::from_utf8(new_file_bytes)?;
     if new_contents.trim().is_empty() {
         return Err(IoError::new(
-            ErrorKind::Other,
-            "cbindgen produced an empty header; ensure FFI exports are marked #[no_mangle] and \
-             declared extern \"C\"",
+            ErrorKind::InvalidData,
+            format!(
+                "cbindgen produced a whitespace-only header for {header_filename}; ensure \
+                 exported symbols are declared extern \"C\"",
+            ),
         )
         .into());
     }
@@ -410,6 +426,11 @@ fn generate_header() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+/// Persist `contents` to `path` when the data differs, creating parent
+/// directories as required.
+///
+/// The function avoids unnecessary writes for unchanged files and provides
+/// contextual I/O errors when filesystem operations fail.
 fn write_if_changed(path: &Path, contents: &str) -> Result<(), Box<dyn Error>> {
     let needs_write = match fs::read_to_string(path) {
         Ok(existing) => existing != contents,
@@ -430,28 +451,41 @@ fn write_if_changed(path: &Path, contents: &str) -> Result<(), Box<dyn Error>> {
         if let Some(parent) = path.parent() {
             ensure_directory(parent)?;
         }
-        fs::write(path, contents)?;
+        fs::write(path, contents).map_err(|err| {
+            IoError::new(
+                err.kind(),
+                format!("failed to write {}: {err}", path.display()),
+            )
+        })?;
     }
 
     Ok(())
 }
 
+/// Ensure `path` exists as a directory, creating it (and parents) as needed.
 fn ensure_directory(path: &Path) -> Result<(), Box<dyn Error>> {
     if path.exists() {
         if !path.is_dir() {
             return Err(IoError::new(
-                ErrorKind::Other,
+                ErrorKind::InvalidInput,
                 format!("Path exists but is not a directory: {}", path.display()),
             )
             .into());
         }
     } else {
-        fs::create_dir_all(path)?;
+        fs::create_dir_all(path).map_err(|err| {
+            IoError::new(
+                err.kind(),
+                format!("failed to create directory {}: {err}", path.display()),
+            )
+        })?;
     }
 
     Ok(())
 }
 
+/// Attempt to mirror the generated header into the repository include
+/// directory.
 fn try_write_repository_header(
     include_dir: &Path,
     file_name: &str,
@@ -468,7 +502,8 @@ fn try_write_repository_header(
 #[cfg(test)]
 mod tests {
     use super::{
-        HEADER_FILENAME, build_config, get_header_filename, rustc_path_is_safe, write_if_changed,
+        HEADER_FILENAME, RUSTC_PATH_LENGTH_LIMIT, build_config, get_header_filename,
+        rustc_path_is_safe, write_if_changed,
     };
     use std::{
         env, fs,
@@ -476,225 +511,241 @@ mod tests {
         path::PathBuf,
     };
 
-    struct TempDirGuard(PathBuf);
+    mod rustc_path_validation {
+        use super::*;
 
-    impl Drop for TempDirGuard {
-        fn drop(&mut self) {
-            let path = &self.0;
-            if let Err(err) = fs::remove_dir_all(path) {
-                eprintln!(
-                    "warning: failed to clean temporary directory {}: {err}",
-                    path.display()
-                );
+        #[test]
+        fn accepts_normal_rustc_paths() {
+            assert!(rustc_path_is_safe("/usr/bin/rustc"));
+
+            #[cfg(windows)]
+            {
+                assert!(rustc_path_is_safe(r"C:/Rust/bin/rustc.exe"));
+                assert!(rustc_path_is_safe(r"C:\Rust\bin\rustc.exe"));
+            }
+        }
+
+        #[test]
+        fn rejects_paths_with_shell_metacharacters() {
+            assert!(!rustc_path_is_safe("/usr/bin/rustc;rm -rf /"));
+            assert!(!rustc_path_is_safe("rustc|malicious"));
+        }
+
+        #[test]
+        fn allows_common_wrappers() {
+            assert!(rustc_path_is_safe("/usr/bin/sccache"));
+            assert!(rustc_path_is_safe("/usr/local/bin/rustc-wrapper"));
+            assert!(rustc_path_is_safe("ccache"));
+        }
+
+        #[test]
+        fn rejects_additional_dangerous_characters() {
+            assert!(!rustc_path_is_safe("rustc\0malicious"));
+            assert!(!rustc_path_is_safe(r#"rustc"evil"#));
+            assert!(!rustc_path_is_safe("rustc'bad'"));
+            assert!(!rustc_path_is_safe("rustc\\inject"));
+            assert!(!rustc_path_is_safe("rustc*glob"));
+            assert!(!rustc_path_is_safe("rustc?wildcard"));
+            assert!(!rustc_path_is_safe("rustc[range]"));
+            assert!(!rustc_path_is_safe("rustc{expansion}"));
+            assert!(!rustc_path_is_safe("rustc(subshell)"));
+            assert!(!rustc_path_is_safe("rustc~home"));
+            assert!(!rustc_path_is_safe("rustc#fragment"));
+            assert!(!rustc_path_is_safe("rustc!history"));
+            assert!(!rustc_path_is_safe("rustc%env"));
+            assert!(!rustc_path_is_safe("rustc^caret"));
+        }
+
+        #[test]
+        fn rejects_path_traversal_attempts() {
+            assert!(!rustc_path_is_safe("/usr/bin/../../../bin/sh"));
+            assert!(!rustc_path_is_safe("../rustc"));
+            assert!(!rustc_path_is_safe("rustc/../evil"));
+        }
+
+        #[test]
+        fn rejects_url_encoded_path_traversal() {
+            assert!(!rustc_path_is_safe("/usr/bin/%2e%2e/sh"));
+            assert!(!rustc_path_is_safe("%2E%2E/rustc"));
+            assert!(!rustc_path_is_safe("rustc/%2e%2E/evil"));
+            assert!(!rustc_path_is_safe("/usr%2e%2e/bin/sh"));
+            assert!(!rustc_path_is_safe("path/to/..%2f../evil"));
+        }
+
+        #[test]
+        fn rejects_malformed_percent_sequences() {
+            assert!(!rustc_path_is_safe("rustc%"));
+            assert!(!rustc_path_is_safe("rustc%2"));
+            assert!(!rustc_path_is_safe("rustc%2G"));
+        }
+
+        #[cfg(unix)]
+        #[test]
+        fn rejects_symlink_pointing_to_unexpected_binary() {
+            use std::os::unix::fs::symlink;
+
+            let temp_dir =
+                std::env::temp_dir().join(format!("mw_build_symlink_test_{}", std::process::id()));
+            let _ = fs::remove_dir_all(&temp_dir);
+            fs::create_dir_all(&temp_dir).expect("failed to create symlink test dir");
+            let _guard = super::file_operations::TempDirGuard(temp_dir.clone());
+
+            let target = temp_dir.join("not_rustc");
+            fs::write(&target, b"echo not rustc").expect("failed to create target file");
+            let link_path = temp_dir.join("rustc");
+            symlink(&target, &link_path).expect("failed to create symlink");
+
+            let link_str = link_path
+                .to_str()
+                .expect("symlink path not valid UTF-8")
+                .to_string();
+            assert!(!rustc_path_is_safe(&link_str));
+        }
+
+        #[test]
+        fn distinguishes_absolute_simple_and_relative_paths() {
+            assert!(rustc_path_is_safe("rustc"));
+            assert!(rustc_path_is_safe("/usr/bin/rustc"));
+            #[cfg(windows)]
+            {
+                assert!(rustc_path_is_safe(r"C:/Rust/bin/rustc.exe"));
+                assert!(rustc_path_is_safe(r"C:\Rust\bin\rustc.exe"));
+            }
+            assert!(!rustc_path_is_safe("bin/rustc"));
+            assert!(!rustc_path_is_safe(r".\rustc.exe"));
+        }
+
+        #[cfg(windows)]
+        #[test]
+        fn accepts_windows_backslash_paths() {
+            assert!(rustc_path_is_safe(r"C:\Rust\bin\rustc.exe"));
+            assert!(rustc_path_is_safe(r"\\\\server\\share\\rustc.exe"));
+        }
+
+        #[test]
+        fn rejects_space_characters_and_url_encoded_spaces() {
+            assert!(!rustc_path_is_safe("rustc malicious"));
+            assert!(!rustc_path_is_safe("/usr/bin/rustc evil"));
+            assert!(!rustc_path_is_safe("rustc%20inject"));
+            assert!(!rustc_path_is_safe("%20rustc"));
+            assert!(!rustc_path_is_safe("rustc%20%20evil"));
+        }
+
+        #[test]
+        fn rejects_flag_injection() {
+            assert!(!rustc_path_is_safe("-Zprint-link-args"));
+            assert!(!rustc_path_is_safe("--help"));
+        }
+
+        #[test]
+        fn rejects_oversized_paths() {
+            let oversized = "a".repeat(RUSTC_PATH_LENGTH_LIMIT + 1);
+            assert!(!rustc_path_is_safe(&oversized));
+        }
+
+        #[test]
+        fn rejects_suspicious_canonical_paths() {
+            assert!(!rustc_path_is_safe("/tmp/../../../bin/sh"));
+        }
+    }
+
+    mod header_configuration {
+        use super::*;
+
+        #[test]
+        fn config_uses_pragma_once_without_include_guard() {
+            let config = build_config("test");
+            assert!(config.pragma_once);
+            assert!(config.include_guard.is_none());
+        }
+
+        #[test]
+        fn cbindgen_config_triggers_rebuild_if_present() {
+            let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            let cbindgen_toml = crate_dir.join("cbindgen.toml");
+            if cbindgen_toml.exists() {
+                assert!(cbindgen_toml.is_file());
+            }
+        }
+
+        #[test]
+        fn header_filename_respects_env_var() {
+            const KEY: &str = "MW_FFI_HEADER_NAME";
+            let original = env::var(KEY).ok();
+
+            env::remove_var(KEY);
+            assert_eq!(get_header_filename(), HEADER_FILENAME);
+
+            env::set_var(KEY, "custom_ffi.h");
+            assert_eq!(get_header_filename(), "custom_ffi.h");
+
+            match original {
+                Some(value) => env::set_var(KEY, value),
+                None => env::remove_var(KEY),
+            }
+        }
+
+        #[test]
+        fn header_filename_validates_format() {
+            const KEY: &str = "MW_FFI_HEADER_NAME";
+            let original = env::var(KEY).ok();
+
+            env::set_var(KEY, "invalid_name");
+            assert_eq!(get_header_filename(), HEADER_FILENAME);
+
+            env::set_var(KEY, "../evil.h");
+            assert_eq!(get_header_filename(), HEADER_FILENAME);
+
+            env::set_var(KEY, "custom.h");
+            assert_eq!(get_header_filename(), "custom.h");
+
+            match original {
+                Some(value) => env::set_var(KEY, value),
+                None => env::remove_var(KEY),
             }
         }
     }
 
-    #[test]
-    fn accepts_normal_rustc_paths() {
-        assert!(rustc_path_is_safe("/usr/bin/rustc"));
+    mod file_operations {
+        use super::*;
 
-        #[cfg(windows)]
-        {
-            assert!(rustc_path_is_safe("C:/Rust/bin/rustc.exe"));
-            assert!(rustc_path_is_safe("C:\\Rust\\bin\\rustc.exe"));
+        pub(super) struct TempDirGuard(pub(super) PathBuf);
+
+        impl Drop for TempDirGuard {
+            fn drop(&mut self) {
+                if let Err(err) = fs::remove_dir_all(&self.0) {
+                    eprintln!(
+                        "warning: failed to clean temporary directory {}: {err}",
+                        self.0.display()
+                    );
+                }
+            }
         }
-    }
 
-    #[test]
-    fn rejects_paths_with_shell_metacharacters() {
-        assert!(!rustc_path_is_safe("/usr/bin/rustc;rm -rf /"));
-        assert!(!rustc_path_is_safe("rustc|malicious"));
-    }
+        #[test]
+        fn write_if_changed_propagates_permission_errors() {
+            let temp_dir = std::env::temp_dir().join(format!(
+                "mw_build_write_permission_test_{}",
+                std::process::id()
+            ));
+            let _ = fs::remove_dir_all(&temp_dir);
+            fs::create_dir_all(&temp_dir).expect("failed to create temp dir");
+            let _guard = TempDirGuard(temp_dir.clone());
 
-    #[test]
-    fn allows_common_wrappers() {
-        assert!(rustc_path_is_safe("/usr/bin/sccache"));
-        assert!(rustc_path_is_safe("/usr/local/bin/rustc-wrapper"));
-        assert!(rustc_path_is_safe("ccache"));
-    }
+            let blocking_path = temp_dir.join("not_a_directory");
+            fs::write(&blocking_path, "marker").expect("failed to create blocking file");
 
-    #[test]
-    fn rejects_additional_dangerous_characters() {
-        assert!(!rustc_path_is_safe("rustc\0malicious"));
-        assert!(!rustc_path_is_safe("rustc\"evil"));
-        assert!(!rustc_path_is_safe("rustc'bad'"));
-        assert!(!rustc_path_is_safe("rustc\\inject"));
-        assert!(!rustc_path_is_safe("rustc*glob"));
-        assert!(!rustc_path_is_safe("rustc?wildcard"));
-        assert!(!rustc_path_is_safe("rustc[range]"));
-        assert!(!rustc_path_is_safe("rustc{expansion}"));
-        assert!(!rustc_path_is_safe("rustc(subshell)"));
-        assert!(!rustc_path_is_safe("rustc~home"));
-        assert!(!rustc_path_is_safe("rustc#fragment"));
-        assert!(!rustc_path_is_safe("rustc!history"));
-        assert!(!rustc_path_is_safe("rustc%env"));
-        assert!(!rustc_path_is_safe("rustc^caret"));
-    }
-
-    #[test]
-    fn rejects_path_traversal_attempts() {
-        assert!(!rustc_path_is_safe("/usr/bin/../../../bin/sh"));
-        assert!(!rustc_path_is_safe("../rustc"));
-        assert!(!rustc_path_is_safe("rustc/../evil"));
-    }
-
-    #[test]
-    fn rejects_url_encoded_path_traversal() {
-        assert!(!rustc_path_is_safe("/usr/bin/%2e%2e/sh"));
-        assert!(!rustc_path_is_safe("%2E%2E/rustc"));
-        assert!(!rustc_path_is_safe("rustc/%2e%2E/evil"));
-        assert!(!rustc_path_is_safe("/usr%2e%2e/bin/sh"));
-        assert!(!rustc_path_is_safe("path/to/..%2f../evil"));
-    }
-
-    #[test]
-    fn rejects_malformed_percent_sequences() {
-        assert!(!rustc_path_is_safe("rustc%"));
-        assert!(!rustc_path_is_safe("rustc%2"));
-        assert!(!rustc_path_is_safe("rustc%2G"));
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn rejects_symlink_pointing_to_unexpected_binary() {
-        use std::os::unix::fs::symlink;
-
-        let temp_dir =
-            std::env::temp_dir().join(format!("mw_build_symlink_test_{}", std::process::id()));
-        let _ = fs::remove_dir_all(&temp_dir);
-        fs::create_dir_all(&temp_dir).expect("failed to create symlink test dir");
-        let _guard = TempDirGuard(temp_dir.clone());
-
-        let target = temp_dir.join("not_rustc");
-        fs::write(&target, b"echo not rustc").expect("failed to create target file");
-        let link_path = temp_dir.join("rustc");
-        symlink(&target, &link_path).expect("failed to create symlink");
-
-        let link_str = link_path
-            .to_str()
-            .expect("symlink path not valid UTF-8")
-            .to_string();
-        assert!(!rustc_path_is_safe(&link_str));
-    }
-
-    #[test]
-    fn distinguishes_absolute_simple_and_relative_paths() {
-        assert!(rustc_path_is_safe("rustc"));
-        assert!(rustc_path_is_safe("/usr/bin/rustc"));
-        #[cfg(windows)]
-        {
-            assert!(rustc_path_is_safe("C:/Rust/bin/rustc.exe"));
-            assert!(rustc_path_is_safe("C:\\Rust\\bin\\rustc.exe"));
+            let child_path = blocking_path.join("child.txt");
+            let err = write_if_changed(&child_path, "changed").expect_err("write should fail");
+            let io_err = err
+                .downcast::<IoError>()
+                .expect("expected io::Error from write failure");
+            assert_eq!(io_err.kind(), ErrorKind::InvalidInput);
+            assert!(
+                io_err
+                    .to_string()
+                    .contains(&blocking_path.display().to_string())
+            );
         }
-        assert!(!rustc_path_is_safe("bin/rustc"));
-        assert!(!rustc_path_is_safe(".\\rustc.exe"));
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn accepts_windows_backslash_paths() {
-        assert!(rustc_path_is_safe("C:\\Rust\\bin\\rustc.exe"));
-        assert!(rustc_path_is_safe("\\\\server\\share\\rustc.exe"));
-    }
-
-    #[test]
-    fn rejects_space_characters_and_url_encoded_spaces() {
-        assert!(!rustc_path_is_safe("rustc malicious"));
-        assert!(!rustc_path_is_safe("/usr/bin/rustc evil"));
-        assert!(!rustc_path_is_safe("rustc%20inject"));
-        assert!(!rustc_path_is_safe("%20rustc"));
-        assert!(!rustc_path_is_safe("rustc%20%20evil"));
-    }
-
-    #[test]
-    fn rejects_flag_injection() {
-        assert!(!rustc_path_is_safe("-Zprint-link-args"));
-        assert!(!rustc_path_is_safe("--help"));
-    }
-
-    #[test]
-    fn rejects_oversized_paths() {
-        let oversized = "a".repeat(4_097);
-        assert!(!rustc_path_is_safe(&oversized));
-    }
-
-    #[test]
-    fn config_uses_pragma_once_without_include_guard() {
-        let config = build_config("test");
-        assert!(config.pragma_once);
-        assert!(config.include_guard.is_none());
-    }
-
-    #[test]
-    fn cbindgen_config_triggers_rebuild_if_present() {
-        let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        let cbindgen_toml = crate_dir.join("cbindgen.toml");
-        if cbindgen_toml.exists() {
-            assert!(cbindgen_toml.is_file());
-        }
-    }
-
-    #[test]
-    fn header_filename_respects_env_var() {
-        const KEY: &str = "MW_FFI_HEADER_NAME";
-        let original = env::var(KEY).ok();
-
-        env::remove_var(KEY);
-        assert_eq!(get_header_filename(), HEADER_FILENAME);
-
-        env::set_var(KEY, "custom_ffi.h");
-        assert_eq!(get_header_filename(), "custom_ffi.h");
-
-        match original {
-            Some(value) => env::set_var(KEY, value),
-            None => env::remove_var(KEY),
-        }
-    }
-
-    #[test]
-    fn header_filename_validates_format() {
-        const KEY: &str = "MW_FFI_HEADER_NAME";
-        let original = env::var(KEY).ok();
-
-        env::set_var(KEY, "invalid_name");
-        assert_eq!(get_header_filename(), HEADER_FILENAME);
-
-        env::set_var(KEY, "../evil.h");
-        assert_eq!(get_header_filename(), HEADER_FILENAME);
-
-        env::set_var(KEY, "custom.h");
-        assert_eq!(get_header_filename(), "custom.h");
-
-        match original {
-            Some(value) => env::set_var(KEY, value),
-            None => env::remove_var(KEY),
-        }
-    }
-
-    #[test]
-    fn write_if_changed_propagates_permission_errors() {
-        let temp_dir = std::env::temp_dir().join(format!(
-            "mw_build_write_permission_test_{}",
-            std::process::id()
-        ));
-        let _ = fs::remove_dir_all(&temp_dir);
-        fs::create_dir_all(&temp_dir).expect("failed to create temp dir");
-        let _guard = TempDirGuard(temp_dir.clone());
-
-        let blocking_path = temp_dir.join("not_a_directory");
-        fs::write(&blocking_path, "marker").expect("failed to create blocking file");
-
-        let child_path = blocking_path.join("child.txt");
-        let err = write_if_changed(&child_path, "changed").expect_err("write should fail");
-        let io_err = err
-            .downcast::<IoError>()
-            .expect("expected io::Error from write failure");
-        assert_eq!(io_err.kind(), ErrorKind::Other);
-    }
-
-    #[test]
-    fn rejects_suspicious_canonical_paths() {
-        assert!(!rustc_path_is_safe("/tmp/../../../bin/sh"));
     }
 }

--- a/rust/unreal-bindings/build.rs
+++ b/rust/unreal-bindings/build.rs
@@ -67,21 +67,30 @@ const HEADER_PREAMBLE_TEMPLATE: &str = r#"/*
 
 /// Represents a `rustc` path that has passed the hardened security validation.
 #[derive(Clone, Debug)]
-pub struct SafeRustcPath(PathBuf);
+pub struct SafeRustcPath {
+    path: PathBuf,
+    _validated: (),
+}
 
 impl SafeRustcPath {
     /// Validate a `rustc` path and wrap it in [`SafeRustcPath`] when the input
     /// satisfies all security checks.
     pub fn validate(candidate: &str) -> Option<Self> {
         if security::rustc_path_is_safe(candidate) {
-            Some(Self(PathBuf::from(candidate)))
+            Some(Self {
+                path: PathBuf::from(candidate),
+                _validated: (),
+            })
         } else {
             None
         }
     }
 
     /// Borrow the underlying path as a [`Path`].
-    pub fn as_path(&self) -> &Path { &self.0 }
+    pub fn as_path(&self) -> &Path { &self.path }
+
+    /// Borrow the validated path as a string slice when it is valid UTF-8.
+    pub fn as_str(&self) -> Option<&str> { self.path.to_str() }
 }
 
 impl AsRef<Path> for SafeRustcPath {
@@ -89,7 +98,7 @@ impl AsRef<Path> for SafeRustcPath {
 }
 
 impl From<SafeRustcPath> for PathBuf {
-    fn from(value: SafeRustcPath) -> Self { value.0 }
+    fn from(value: SafeRustcPath) -> Self { value.path }
 }
 
 fn get_header_filename() -> String {
@@ -411,7 +420,19 @@ mod tests {
             let tool_str = tool.to_str().expect("path not UTF-8");
             let validated = SafeRustcPath::validate(tool_str).expect("expected validation success");
             assert_eq!(validated.as_path(), Path::new(tool_str));
+            assert_eq!(validated.as_str(), Some(tool_str));
             drop(guard);
+        }
+
+        #[test]
+        fn safe_rustc_path_prevents_invalid_construction() {
+            assert!(SafeRustcPath::validate("rustc").is_some());
+            assert!(SafeRustcPath::validate("../evil").is_none());
+
+            let validated = SafeRustcPath::validate("rustc").expect("expected safe rustc");
+            let path_buf: PathBuf = validated.clone().into();
+            assert_eq!(path_buf, PathBuf::from("rustc"));
+            assert!(validated.as_str().is_some());
         }
     }
 

--- a/rust/unreal-bindings/build.rs
+++ b/rust/unreal-bindings/build.rs
@@ -106,10 +106,14 @@ fn contains_forbidden_percent_encoding(value: &str) -> bool {
     let bytes = value.as_bytes();
     let mut index = 0;
 
-    while index + 2 < bytes.len() {
+    while index < bytes.len() {
         if bytes[index] != b'%' {
             index += 1;
             continue;
+        }
+
+        if index + 2 >= bytes.len() {
+            return true;
         }
 
         let high = match decode_hex_digit(bytes[index + 1]) {
@@ -191,7 +195,6 @@ fn rustc_path_is_safe(rustc: &str) -> bool {
                 | '~'
                 | '#'
                 | '!'
-                | '%'
                 | '^'
                 | ' '
         )
@@ -543,6 +546,13 @@ mod tests {
         assert!(!rustc_path_is_safe("rustc/%2e%2E/evil"));
         assert!(!rustc_path_is_safe("/usr%2e%2e/bin/sh"));
         assert!(!rustc_path_is_safe("path/to/..%2f../evil"));
+    }
+
+    #[test]
+    fn rejects_malformed_percent_sequences() {
+        assert!(!rustc_path_is_safe("rustc%"));
+        assert!(!rustc_path_is_safe("rustc%2"));
+        assert!(!rustc_path_is_safe("rustc%2G"));
     }
 
     #[cfg(unix)]

--- a/rust/unreal-bindings/build.rs
+++ b/rust/unreal-bindings/build.rs
@@ -154,10 +154,11 @@ fn is_allowed_compiler_name(value: &str) -> bool {
         || lower.starts_with("rustc_")
 }
 
-// NOTE: We validate both the raw path string and the canonicalised filesystem
-// location to defend against obvious traversal attacks (including symlink
-// chains) while still delegating race-condition handling to the actual `rustc`
-// invocation.
+// NOTE: We validate both the raw path string and (when possible) the
+// canonicalised filesystem location to defend against obvious traversal
+// attacks (including symlink chains) while still delegating race-condition
+// handling to the actual `rustc` invocation. On Windows/UNC paths we fall back
+// to validating the raw components if canonicalisation is not available.
 fn rustc_path_is_safe(rustc: &str) -> bool {
     if rustc.is_empty() || rustc.len() >= 4_096 {
         return false;
@@ -242,6 +243,7 @@ fn rustc_path_is_safe(rustc: &str) -> bool {
 
     let inspected_path = match fs::canonicalize(path) {
         Ok(path) => path,
+        Err(_) if is_absolute_windows || is_unc => PathBuf::from(rustc),
         Err(_) => return false,
     };
 
@@ -252,11 +254,6 @@ fn rustc_path_is_safe(rustc: &str) -> bool {
 
     match file_name.as_deref() {
         Some(name) if is_allowed_compiler_name(name) => {},
-        _ => return false,
-    }
-
-    match fs::metadata(&inspected_path) {
-        Ok(metadata) if metadata.is_file() => {},
         _ => return false,
     }
 

--- a/rust/unreal-bindings/build.rs
+++ b/rust/unreal-bindings/build.rs
@@ -134,9 +134,8 @@ fn get_header_filename() -> String {
 
 fn main() {
     let rustc = env::var("RUSTC").unwrap_or_else(|_| "rustc".to_string());
-    let _validated_rustc = SafeRustcPath::validate(&rustc).unwrap_or_else(|| {
-        panic!("refusing to execute rustc with potentially malicious path: {rustc}");
-    });
+    let _validated_rustc = SafeRustcPath::validate(&rustc)
+        .expect("refusing to execute rustc with potentially malicious path");
 
     if let Err(err) = generate_header() {
         panic!("failed to generate C header: {err}");
@@ -182,25 +181,22 @@ fn emit_rerun_for_sources(src_dir: &Path) -> Result<(), Box<dyn Error>> {
         return Ok(());
     }
 
-    let mut stack = vec![src_dir.to_path_buf()];
-    let mut files = Vec::new();
-
-    while let Some(dir) = stack.pop() {
-        for entry in fs::read_dir(&dir)? {
+    fn visit(dir: &Path) -> Result<(), Box<dyn Error>> {
+        for entry in fs::read_dir(dir)? {
             let entry = entry?;
             let path = entry.path();
+
             if entry.file_type()?.is_dir() {
-                stack.push(path);
+                visit(&path)?;
             } else if path.extension().map_or(false, |ext| ext == "rs") {
-                files.push(path);
+                println!("cargo:rerun-if-changed={}", path.display());
             }
         }
+
+        Ok(())
     }
 
-    files.sort();
-    for file in files {
-        println!("cargo:rerun-if-changed={}", file.display());
-    }
+    visit(src_dir)?;
 
     Ok(())
 }

--- a/rust/unreal-bindings/build.rs
+++ b/rust/unreal-bindings/build.rs
@@ -63,7 +63,26 @@ const HEADER_PREAMBLE_TEMPLATE: &str = r#"/*
  *         }
  *         return exit_code;
  *     }
- */"#;
+*/"#;
+
+/// Represents a `rustc` path that has passed the hardened security validation.
+#[derive(Clone, Debug)]
+pub struct SafeRustcPath(PathBuf);
+
+impl SafeRustcPath {
+    /// Validate a `rustc` path and wrap it in [`SafeRustcPath`] when the input
+    /// satisfies all security checks.
+    pub fn validate(candidate: &str) -> Option<Self> {
+        if security::rustc_path_is_safe(candidate) {
+            Some(Self(PathBuf::from(candidate)))
+        } else {
+            None
+        }
+    }
+
+    /// Borrow the underlying path as a [`Path`].
+    pub fn as_path(&self) -> &Path { &self.0 }
+}
 
 fn get_header_filename() -> String {
     const ENV_KEY: &str = "MW_FFI_HEADER_NAME";
@@ -94,261 +113,13 @@ fn get_header_filename() -> String {
     }
 }
 
-/// Security-oriented helpers that validate toolchain execution paths before
-/// invoking `rustc`.
-mod security {
-    use std::{
-        fs,
-        path::{Component, Path, PathBuf},
-    };
-
-    use super::RUSTC_PATH_LENGTH_LIMIT;
-
-    fn decode_hex_digit(byte: u8) -> Option<u8> {
-        match byte {
-            b'0'..=b'9' => Some(byte - b'0'),
-            b'a'..=b'f' => Some(byte - b'a' + 10),
-            b'A'..=b'F' => Some(byte - b'A' + 10),
-            _ => None,
-        }
-    }
-
-    fn contains_forbidden_percent_encoding(value: &str) -> bool {
-        let bytes = value.as_bytes();
-        let mut index = 0;
-
-        while index < bytes.len() {
-            if bytes[index] != b'%' {
-                index += 1;
-                continue;
-            }
-
-            let Some(high_index) = index.checked_add(1) else {
-                return true;
-            };
-            let Some(low_index) = index.checked_add(2) else {
-                return true;
-            };
-
-            if high_index >= bytes.len() || low_index >= bytes.len() {
-                return true;
-            }
-
-            let high = match bytes.get(high_index).copied().and_then(decode_hex_digit) {
-                Some(value) => value,
-                None => return true,
-            };
-            let low = match bytes.get(low_index).copied().and_then(decode_hex_digit) {
-                Some(value) => value,
-                None => return true,
-            };
-            let decoded = (high << 4) | low;
-
-            match decoded {
-                b'.' | b'/' | b'\\' | b' ' | b'\t' | b'\n' | b'\r' => return true,
-                _ => {},
-            }
-
-            index += 3;
-        }
-
-        false
-    }
-
-    fn is_allowed_compiler_name(value: &str) -> bool {
-        let lower = value.to_ascii_lowercase();
-
-        matches!(
-            lower.as_str(),
-            "rustc"
-                | "rustc.exe"
-                | "rustc.bat"
-                | "rustc.cmd"
-                | "rustc_driver"
-                | "rustc_driver.exe"
-                | "rustc-wrapper"
-                | "rustc-wrapper.exe"
-                | "sccache"
-                | "sccache.exe"
-                | "ccache"
-                | "ccache.exe"
-        ) || lower.starts_with("rustc-")
-            || lower.starts_with("rustc_")
-    }
-
-    /// Evaluate whether a provided `rustc` executable path is considered safe
-    /// to execute.
-    ///
-    /// The validator aggressively rejects obvious command-injection vectors,
-    /// percent-encoded traversal attempts, and canonicalised paths that escape
-    /// a curated allowlist of toolchain directories. Canonicalisation is
-    /// only used to reduce symlink and traversal risks; the build
-    /// immediately hands off to Cargo after validation to avoid extending
-    /// the TOCTOU window.
-    pub(crate) fn rustc_path_is_safe(rustc: &str) -> bool {
-        if rustc.is_empty() || rustc.len() >= RUSTC_PATH_LENGTH_LIMIT {
-            return false;
-        }
-
-        if rustc.chars().any(|ch| {
-            matches!(
-                ch,
-                ';' | '&'
-                    | '|'
-                    | '`'
-                    | '$'
-                    | '>'
-                    | '<'
-                    | '\n'
-                    | '\r'
-                    | '\0'
-                    | '\t'
-                    | '"'
-                    | '\''
-                    | '*'
-                    | '?'
-                    | '['
-                    | ']'
-                    | '{'
-                    | '}'
-                    | '('
-                    | ')'
-                    | '~'
-                    | '#'
-                    | '!'
-                    | '^'
-                    | ' '
-            )
-        }) {
-            return false;
-        }
-
-        if rustc.contains("..") || contains_forbidden_percent_encoding(rustc) {
-            return false;
-        }
-
-        if rustc.starts_with('-') {
-            return false;
-        }
-
-        let path = Path::new(rustc);
-        if path
-            .components()
-            .any(|component| matches!(component, Component::ParentDir | Component::CurDir))
-        {
-            return false;
-        }
-
-        let is_simple = !rustc.contains('/') && !rustc.contains('\\');
-        let bytes = rustc.as_bytes();
-        let is_absolute_unix = rustc.starts_with('/');
-        let is_absolute_windows = bytes.len() >= 3
-            && bytes[0].is_ascii_alphabetic()
-            && bytes[1] == b':'
-            && matches!(bytes[2], b'/' | b'\\');
-        let is_unc = if bytes.len() >= 5 && bytes[0] == b'\\' && bytes[1] == b'\\' {
-            let third = bytes[2];
-            third != b'\\' && third != b'/' && bytes[2..].contains(&b'\\')
-        } else {
-            false
-        };
-
-        if !(is_simple || is_absolute_unix || is_absolute_windows || is_unc) {
-            return false;
-        }
-
-        if is_simple && rustc.contains(':') {
-            return false;
-        }
-
-        if is_simple {
-            return is_allowed_compiler_name(rustc);
-        }
-
-        let (inspected_path, canonicalized) = match fs::canonicalize(path) {
-            Ok(path) => (path, true),
-            Err(_) if is_absolute_windows || is_unc => (PathBuf::from(rustc), false),
-            Err(_) => return false,
-        };
-
-        if canonicalized {
-            match fs::metadata(&inspected_path) {
-                Ok(metadata) => {
-                    if !metadata.is_file() {
-                        return false;
-                    }
-
-                    #[cfg(unix)]
-                    {
-                        use std::os::unix::fs::PermissionsExt;
-
-                        // Reject toolchains that are world-writable to avoid executing binaries
-                        // attackers could swap between validation and use.
-                        const WORLD_WRITABLE: u32 = 0o002;
-                        if metadata.permissions().mode() & WORLD_WRITABLE != 0 {
-                            return false;
-                        }
-                    }
-                },
-                Err(_) => return false,
-            }
-        }
-
-        if let Some(parent) = inspected_path.parent() {
-            let parent_lower = parent.to_string_lossy().to_ascii_lowercase();
-            const ALLOWED_PREFIXES: &[&str] = &[
-                "/usr/bin",
-                "/usr/local/bin",
-                "/opt/",
-                "c:/rust",
-                "c:/program files",
-                "c:/users",
-                "c\\rust",
-                "c\\program files",
-                "c\\users",
-            ];
-
-            let allowed = parent_lower.starts_with("\\\\")
-                || ALLOWED_PREFIXES
-                    .iter()
-                    .any(|prefix| parent_lower.starts_with(prefix))
-                || parent_lower.contains("/.cargo/bin")
-                || parent_lower.contains("\\.cargo\\bin")
-                || parent_lower.contains("/.rustup/toolchains")
-                || parent_lower.contains("\\.rustup\\toolchains")
-                || parent_lower.contains("program files");
-
-            if !allowed {
-                return false;
-            }
-        }
-
-        let file_name = inspected_path
-            .file_name()
-            .and_then(|name| name.to_str())
-            .map(|name| name.to_ascii_lowercase());
-
-        match file_name.as_deref() {
-            Some(name) if is_allowed_compiler_name(name) => {},
-            _ => return false,
-        }
-
-        true
-    }
-
-    #[cfg(test)]
-    pub(super) fn contains_forbidden_percent_encoding_public(value: &str) -> bool {
-        contains_forbidden_percent_encoding(value)
-    }
-}
-
-pub(crate) use security::rustc_path_is_safe;
+#[path = "src/security.rs"] mod security;
 
 fn main() {
     let rustc = env::var("RUSTC").unwrap_or_else(|_| "rustc".to_string());
-    if !rustc_path_is_safe(&rustc) {
+    let _validated_rustc = SafeRustcPath::validate(&rustc).unwrap_or_else(|| {
         panic!("refusing to execute rustc with potentially malicious path: {rustc}");
-    }
+    });
 
     if let Err(err) = generate_header() {
         panic!("failed to generate C header: {err}");
@@ -583,37 +354,18 @@ fn try_write_repository_header(
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        HEADER_FILENAME, RUSTC_PATH_LENGTH_LIMIT, build_config, get_header_filename,
-        rustc_path_is_safe, security, write_if_changed,
-    };
-    use std::{
-        env, fs,
-        io::{Error as IoError, ErrorKind},
-        path::PathBuf,
-        time::{SystemTime, UNIX_EPOCH},
-    };
+    use super::*;
+    use std::path::{Path, PathBuf};
 
-    use proptest::prelude::*;
-
-    mod test_constants {
-        pub(super) const FORBIDDEN_SHELL_CHARS: &[char] = &[
-            ';', '&', '|', '`', '$', '>', '<', '\n', '\r', '\0', '\t', '"', '\'', '*', '?', '[',
-            ']', '{', '}', '(', ')', '~', '#', '!', '^', ' ',
-        ];
-
-        pub(super) const ALLOWED_WRAPPER_NAMES: &[&str] =
-            &["rustc", "rustc.exe", "rustc-wrapper", "sccache", "ccache"];
-
-        pub(super) const NON_HEX_CHARS: &[char] = &['g', 'G', 'z', 'Z', '/', ':', '-', '_'];
-        pub(super) const SAFE_HEX_DIGITS: &[char] = &[
-            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', 'A',
-            'B', 'C', 'D', 'E', 'F',
-        ];
-    }
-
-    mod test_helpers {
+    mod fixtures {
         use super::*;
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        pub(super) struct TempDirGuard(pub(super) PathBuf);
+
+        impl Drop for TempDirGuard {
+            fn drop(&mut self) { let _ = fs::remove_dir_all(&self.0); }
+        }
 
         pub(super) fn unique_temp_dir(prefix: &str) -> PathBuf {
             let timestamp = SystemTime::now()
@@ -622,271 +374,36 @@ mod tests {
                 .as_nanos();
             env::temp_dir().join(format!("{prefix}_{:x}_{:x}", std::process::id(), timestamp))
         }
+
+        pub(super) fn create_tool(path: &Path, contents: &[u8]) {
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).expect("failed to create parent directory");
+            }
+            fs::write(path, contents).expect("failed to create tool contents");
+        }
     }
 
-    mod rustc_path_validation {
+    mod safe_rustc_path {
         use super::*;
+        use fixtures::{TempDirGuard, create_tool, unique_temp_dir};
 
         #[test]
-        fn accepts_normal_rustc_paths() {
-            assert!(rustc_path_is_safe("/usr/bin/rustc"));
-
-            #[cfg(windows)]
-            {
-                assert!(rustc_path_is_safe(r"C:/Rust/bin/rustc.exe"));
-                assert!(rustc_path_is_safe(r"C:\Rust\bin\rustc.exe"));
-            }
+        fn validate_rejects_untrusted_paths() {
+            assert!(SafeRustcPath::validate("../rustc").is_none());
+            assert!(SafeRustcPath::validate("rustc malicious").is_none());
         }
 
         #[test]
-        fn rejects_paths_with_shell_metacharacters() {
-            assert!(!rustc_path_is_safe("/usr/bin/rustc;rm -rf /"));
-            assert!(!rustc_path_is_safe("rustc|malicious"));
-        }
+        fn validate_wraps_safe_paths() {
+            let root = unique_temp_dir("mw_safe_rustc");
+            let guard = TempDirGuard(root.clone());
+            let tool = root.join(".cargo/bin/rustc");
+            create_tool(&tool, b"#!/bin/true\n");
 
-        proptest! {
-            #[test]
-            fn rejects_forbidden_shell_chars(
-                ch in prop::sample::select(test_constants::FORBIDDEN_SHELL_CHARS.to_vec())
-            ) {
-                let candidate = format!("rustc{ch}payload");
-                prop_assert!(!rustc_path_is_safe(&candidate));
-            }
-        }
-
-        #[test]
-        fn allows_common_wrappers() {
-            assert!(rustc_path_is_safe("/usr/bin/sccache"));
-            assert!(rustc_path_is_safe("/usr/local/bin/rustc-wrapper"));
-            assert!(rustc_path_is_safe("ccache"));
-        }
-
-        proptest! {
-            #[test]
-            fn allows_known_wrapper_names(
-                wrapper in prop::sample::select(test_constants::ALLOWED_WRAPPER_NAMES.to_vec())
-            ) {
-                prop_assert!(rustc_path_is_safe(wrapper));
-            }
-        }
-
-        #[test]
-        fn rejects_additional_dangerous_characters() {
-            assert!(!rustc_path_is_safe("rustc\0malicious"));
-            assert!(!rustc_path_is_safe(r#"rustc"evil"#));
-            assert!(!rustc_path_is_safe("rustc'bad'"));
-            assert!(!rustc_path_is_safe("rustc\\inject"));
-            assert!(!rustc_path_is_safe("rustc*glob"));
-            assert!(!rustc_path_is_safe("rustc?wildcard"));
-            assert!(!rustc_path_is_safe("rustc[range]"));
-            assert!(!rustc_path_is_safe("rustc{expansion}"));
-            assert!(!rustc_path_is_safe("rustc(subshell)"));
-            assert!(!rustc_path_is_safe("rustc~home"));
-            assert!(!rustc_path_is_safe("rustc#fragment"));
-            assert!(!rustc_path_is_safe("rustc!history"));
-            assert!(!rustc_path_is_safe("rustc%env"));
-            assert!(!rustc_path_is_safe("rustc^caret"));
-        }
-
-        #[test]
-        fn rejects_path_traversal_attempts() {
-            assert!(!rustc_path_is_safe("/usr/bin/../../../bin/sh"));
-            assert!(!rustc_path_is_safe("../rustc"));
-            assert!(!rustc_path_is_safe("rustc/../evil"));
-        }
-
-        #[test]
-        fn rejects_url_encoded_path_traversal() {
-            assert!(!rustc_path_is_safe("/usr/bin/%2e%2e/sh"));
-            assert!(!rustc_path_is_safe("%2E%2E/rustc"));
-            assert!(!rustc_path_is_safe("rustc/%2e%2E/evil"));
-            assert!(!rustc_path_is_safe("/usr%2e%2e/bin/sh"));
-            assert!(!rustc_path_is_safe("path/to/..%2f../evil"));
-        }
-
-        #[test]
-        fn rejects_malformed_percent_sequences() {
-            assert!(!rustc_path_is_safe("rustc%"));
-            assert!(!rustc_path_is_safe("rustc%2"));
-            assert!(!rustc_path_is_safe("rustc%2G"));
-            assert!(!rustc_path_is_safe("%"));
-        }
-
-        #[test]
-        fn rejects_incomplete_percent_at_end() {
-            assert!(security::contains_forbidden_percent_encoding_public("%"));
-            assert!(security::contains_forbidden_percent_encoding_public(
-                "rustc%"
-            ));
-            assert!(security::contains_forbidden_percent_encoding_public(
-                "rustc%2"
-            ));
-        }
-
-        proptest! {
-            #[test]
-            fn rejects_non_hex_percent_sequences(
-                high in prop::sample::select(test_constants::NON_HEX_CHARS.to_vec()),
-                low in prop::sample::select(test_constants::NON_HEX_CHARS.to_vec())
-            ) {
-                let candidate = format!("%{high}{low}");
-                prop_assert!(security::contains_forbidden_percent_encoding_public(&candidate));
-            }
-        }
-
-        #[test]
-        fn allows_harmless_percent_sequences() {
-            let base = test_helpers::unique_temp_dir("mw_percent_test");
-            let cargo_bin = base.join(".cargo/bin");
-            fs::create_dir_all(&cargo_bin).expect("failed to create cargo bin directory");
-            let _guard = super::file_operations::TempDirGuard(base.clone());
-
-            let tool_path = cargo_bin.join("rustc%41");
-            fs::write(&tool_path, b"#!/bin/true\n").expect("failed to create dummy compiler");
-
-            let tool_str = tool_path
-                .to_str()
-                .expect("path not valid UTF-8")
-                .to_string();
-            assert!(rustc_path_is_safe(&tool_str));
-        }
-
-        proptest! {
-            #[test]
-            fn allows_safe_percent_sequences(
-                high in prop::sample::select(test_constants::SAFE_HEX_DIGITS.to_vec()),
-                low in prop::sample::select(test_constants::SAFE_HEX_DIGITS.to_vec()),
-            ) {
-                let pair = format!("{high}{low}");
-                if let Ok(decoded) = u8::from_str_radix(&pair, 16) {
-                    prop_assume!(!matches!(decoded, b'.' | b'/' | b'\\' | b' ' | b'\t' | b'\n' | b'\r'));
-
-                    let candidate = format!("/usr/local/bin/rustc%{pair}");
-                    prop_assert!(rustc_path_is_safe(&candidate));
-                }
-            }
-        }
-
-        #[cfg(unix)]
-        #[test]
-        fn rejects_symlink_pointing_to_unexpected_binary() {
-            use std::os::unix::fs::symlink;
-
-            let temp_dir = test_helpers::unique_temp_dir("mw_build_symlink_test");
-            let _ = fs::remove_dir_all(&temp_dir);
-            fs::create_dir_all(&temp_dir).expect("failed to create symlink test dir");
-            let _guard = super::file_operations::TempDirGuard(temp_dir.clone());
-
-            let target = temp_dir.join("not_rustc");
-            fs::write(&target, b"echo not rustc").expect("failed to create target file");
-            let link_path = temp_dir.join("rustc");
-            symlink(&target, &link_path).expect("failed to create symlink");
-
-            let link_str = link_path
-                .to_str()
-                .expect("symlink path not valid UTF-8")
-                .to_string();
-            assert!(!rustc_path_is_safe(&link_str));
-        }
-
-        #[cfg(unix)]
-        #[test]
-        fn rejects_world_writable_compiler() {
-            use std::os::unix::fs::PermissionsExt;
-
-            let temp_dir = test_helpers::unique_temp_dir("mw_world_writable");
-            let cargo_bin = temp_dir.join(".cargo/bin");
-            fs::create_dir_all(&cargo_bin).expect("failed to create cargo bin directory");
-            let _guard = super::file_operations::TempDirGuard(temp_dir.clone());
-
-            let compiler_path = cargo_bin.join("rustc");
-            fs::write(&compiler_path, b"#!/bin/true\n").expect("failed to create compiler stub");
-
-            let mut perms = fs::metadata(&compiler_path)
-                .expect("failed to fetch metadata")
-                .permissions();
-            perms.set_mode(0o777);
-            fs::set_permissions(&compiler_path, perms).expect("failed to update permissions");
-
-            let compiler_str = compiler_path
-                .to_str()
-                .expect("path not valid UTF-8")
-                .to_string();
-            assert!(!rustc_path_is_safe(&compiler_str));
-        }
-
-        #[test]
-        fn distinguishes_absolute_simple_and_relative_paths() {
-            assert!(rustc_path_is_safe("rustc"));
-            assert!(rustc_path_is_safe("/usr/bin/rustc"));
-            #[cfg(windows)]
-            {
-                assert!(rustc_path_is_safe(r"C:/Rust/bin/rustc.exe"));
-                assert!(rustc_path_is_safe(r"C:\Rust\bin\rustc.exe"));
-            }
-            assert!(!rustc_path_is_safe("bin/rustc"));
-            assert!(!rustc_path_is_safe(r".\rustc.exe"));
-        }
-
-        #[cfg(windows)]
-        #[test]
-        fn accepts_windows_backslash_paths() {
-            assert!(rustc_path_is_safe(r"C:\Rust\bin\rustc.exe"));
-            assert!(rustc_path_is_safe(r"\\\\server\\share\\rustc.exe"));
-        }
-
-        #[test]
-        fn rejects_space_characters_and_url_encoded_spaces() {
-            assert!(!rustc_path_is_safe("rustc malicious"));
-            assert!(!rustc_path_is_safe("/usr/bin/rustc evil"));
-            assert!(!rustc_path_is_safe("rustc%20inject"));
-            assert!(!rustc_path_is_safe("%20rustc"));
-            assert!(!rustc_path_is_safe("rustc%20%20evil"));
-        }
-
-        #[test]
-        fn rejects_flag_injection() {
-            assert!(!rustc_path_is_safe("-Zprint-link-args"));
-            assert!(!rustc_path_is_safe("--help"));
-        }
-
-        #[test]
-        fn rejects_oversized_paths() {
-            let oversized = "a".repeat(RUSTC_PATH_LENGTH_LIMIT + 1);
-            assert!(!rustc_path_is_safe(&oversized));
-        }
-
-        #[test]
-        fn rejects_suspicious_canonical_paths() {
-            assert!(!rustc_path_is_safe("/tmp/../../../bin/sh"));
-        }
-
-        #[test]
-        fn enforces_directory_allowlist() {
-            let allowed_root = test_helpers::unique_temp_dir("mw_allowlist_ok");
-            let allowed_bin = allowed_root.join(".cargo/bin");
-            fs::create_dir_all(&allowed_bin).expect("failed to create allowed bin directory");
-            let allowed_guard = super::file_operations::TempDirGuard(allowed_root.clone());
-            let allowed_path = allowed_bin.join("rustc");
-            fs::write(&allowed_path, b"#!/bin/true\n").expect("failed to create allowed tool");
-            let allowed_str = allowed_path
-                .to_str()
-                .expect("allowed path not UTF-8")
-                .to_string();
-            assert!(rustc_path_is_safe(&allowed_str));
-            drop(allowed_guard);
-
-            let disallowed_root = test_helpers::unique_temp_dir("mw_allowlist_blocked");
-            fs::create_dir_all(&disallowed_root).expect("failed to create disallowed dir");
-            let _disallowed_guard = super::file_operations::TempDirGuard(disallowed_root.clone());
-            let disallowed_path = disallowed_root.join("rustc");
-            fs::write(&disallowed_path, b"#!/bin/true\n")
-                .expect("failed to create disallowed tool");
-            let disallowed_str = disallowed_path
-                .to_str()
-                .expect("disallowed path not UTF-8")
-                .to_string();
-            assert!(!rustc_path_is_safe(&disallowed_str));
+            let tool_str = tool.to_str().expect("path not UTF-8");
+            let validated = SafeRustcPath::validate(tool_str).expect("expected validation success");
+            assert_eq!(validated.as_path(), Path::new(tool_str));
+            drop(guard);
         }
     }
 
@@ -949,26 +466,11 @@ mod tests {
 
     mod file_operations {
         use super::*;
-
-        pub(super) struct TempDirGuard(pub(super) PathBuf);
-
-        impl Drop for TempDirGuard {
-            fn drop(&mut self) {
-                if let Err(err) = fs::remove_dir_all(&self.0) {
-                    eprintln!(
-                        "warning: failed to clean temporary directory {}: {err}",
-                        self.0.display()
-                    );
-                }
-            }
-        }
+        use fixtures::{TempDirGuard, unique_temp_dir};
 
         #[test]
         fn write_if_changed_propagates_permission_errors() {
-            let temp_dir = std::env::temp_dir().join(format!(
-                "mw_build_write_permission_test_{}",
-                std::process::id()
-            ));
+            let temp_dir = unique_temp_dir("mw_build_write_permission_test");
             let _ = fs::remove_dir_all(&temp_dir);
             fs::create_dir_all(&temp_dir).expect("failed to create temp dir");
             let _guard = TempDirGuard(temp_dir.clone());

--- a/rust/unreal-bindings/build.rs
+++ b/rust/unreal-bindings/build.rs
@@ -273,8 +273,24 @@ mod security {
 
         if canonicalized {
             match fs::metadata(&inspected_path) {
-                Ok(metadata) if metadata.is_file() => {},
-                _ => return false,
+                Ok(metadata) => {
+                    if !metadata.is_file() {
+                        return false;
+                    }
+
+                    #[cfg(unix)]
+                    {
+                        use std::os::unix::fs::PermissionsExt;
+
+                        // Reject toolchains that are world-writable to avoid executing binaries
+                        // attackers could swap between validation and use.
+                        const WORLD_WRITABLE: u32 = 0o002;
+                        if metadata.permissions().mode() & WORLD_WRITABLE != 0 {
+                            return false;
+                        }
+                    }
+                },
+                Err(_) => return false,
             }
         }
 
@@ -771,6 +787,32 @@ mod tests {
                 .expect("symlink path not valid UTF-8")
                 .to_string();
             assert!(!rustc_path_is_safe(&link_str));
+        }
+
+        #[cfg(unix)]
+        #[test]
+        fn rejects_world_writable_compiler() {
+            use std::os::unix::fs::PermissionsExt;
+
+            let temp_dir = test_helpers::unique_temp_dir("mw_world_writable");
+            let cargo_bin = temp_dir.join(".cargo/bin");
+            fs::create_dir_all(&cargo_bin).expect("failed to create cargo bin directory");
+            let _guard = super::file_operations::TempDirGuard(temp_dir.clone());
+
+            let compiler_path = cargo_bin.join("rustc");
+            fs::write(&compiler_path, b"#!/bin/true\n").expect("failed to create compiler stub");
+
+            let mut perms = fs::metadata(&compiler_path)
+                .expect("failed to fetch metadata")
+                .permissions();
+            perms.set_mode(0o777);
+            fs::set_permissions(&compiler_path, perms).expect("failed to update permissions");
+
+            let compiler_str = compiler_path
+                .to_str()
+                .expect("path not valid UTF-8")
+                .to_string();
+            assert!(!rustc_path_is_safe(&compiler_str));
         }
 
         #[test]

--- a/rust/unreal-bindings/build.rs
+++ b/rust/unreal-bindings/build.rs
@@ -3,7 +3,7 @@ use std::{
     error::Error,
     fs,
     io::{Error as IoError, ErrorKind},
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
 };
 
 use cbindgen::{Builder, Config, DocumentationLength, Language};
@@ -93,15 +93,71 @@ fn get_header_filename() -> String {
     }
 }
 
-// NOTE: We purposefully keep `rustc_path_is_safe` focused on rejecting
-// obviously malicious *path strings* instead of interrogating filesystem
-// metadata. Per Rust security guidance (e.g., CVE-2022-21658), performing a
-// separate `stat`/`symlink_metadata` check prior to execution introduces a
-// time-of-check/time-of-use race where an attacker can swap the executable
-// between validation and use. Cargo will attempt to execute the compiler
-// immediately after this function, so we only filter clearly dangerous
-// characters and traversal attempts here and let the `rustc` invocation surface
-// any filesystem failures.
+fn decode_hex_digit(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn contains_forbidden_percent_encoding(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    let mut index = 0;
+
+    while index + 2 < bytes.len() {
+        if bytes[index] != b'%' {
+            index += 1;
+            continue;
+        }
+
+        let high = match decode_hex_digit(bytes[index + 1]) {
+            Some(value) => value,
+            None => return true,
+        };
+        let low = match decode_hex_digit(bytes[index + 2]) {
+            Some(value) => value,
+            None => return true,
+        };
+        let decoded = (high << 4) | low;
+
+        match decoded {
+            b'.' | b'/' | b'\\' | b' ' | b'\t' | b'\n' | b'\r' => return true,
+            _ => {},
+        }
+
+        index += 3;
+    }
+
+    false
+}
+
+fn is_allowed_compiler_name(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+
+    matches!(
+        lower.as_str(),
+        "rustc"
+            | "rustc.exe"
+            | "rustc.bat"
+            | "rustc.cmd"
+            | "rustc_driver"
+            | "rustc_driver.exe"
+            | "rustc-wrapper"
+            | "rustc-wrapper.exe"
+            | "sccache"
+            | "sccache.exe"
+            | "ccache"
+            | "ccache.exe"
+    ) || lower.starts_with("rustc-")
+        || lower.starts_with("rustc_")
+}
+
+// NOTE: We validate both the raw path string and the canonicalised filesystem
+// location to defend against obvious traversal attacks (including symlink
+// chains) while still delegating race-condition handling to the actual `rustc`
+// invocation.
 fn rustc_path_is_safe(rustc: &str) -> bool {
     if rustc.is_empty() || rustc.len() >= 4_096 {
         return false;
@@ -142,12 +198,19 @@ fn rustc_path_is_safe(rustc: &str) -> bool {
         return false;
     }
 
-    let lower = rustc.to_ascii_lowercase();
-    if rustc.contains("..") || lower.contains("%2e%2e") || lower.contains("%20") {
+    if rustc.contains("..") || contains_forbidden_percent_encoding(rustc) {
         return false;
     }
 
     if rustc.starts_with('-') {
+        return false;
+    }
+
+    let path = Path::new(rustc);
+    if path
+        .components()
+        .any(|component| matches!(component, Component::ParentDir | Component::CurDir))
+    {
         return false;
     }
 
@@ -173,6 +236,30 @@ fn rustc_path_is_safe(rustc: &str) -> bool {
         return false;
     }
 
+    if is_simple {
+        return is_allowed_compiler_name(rustc);
+    }
+
+    let inspected_path = match fs::canonicalize(path) {
+        Ok(path) => path,
+        Err(_) => return false,
+    };
+
+    let file_name = inspected_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| name.to_ascii_lowercase());
+
+    match file_name.as_deref() {
+        Some(name) if is_allowed_compiler_name(name) => {},
+        _ => return false,
+    }
+
+    match fs::metadata(&inspected_path) {
+        Ok(metadata) if metadata.is_file() => {},
+        _ => return false,
+    }
+
     true
 }
 
@@ -191,6 +278,7 @@ fn build_config(header_preamble: &str) -> Config {
     Config {
         language: Language::C,
         pragma_once: true,
+        include_guard: None,
         cpp_compat: true,
         include_version: true,
         autogen_warning: Some(
@@ -204,11 +292,49 @@ fn build_config(header_preamble: &str) -> Config {
     }
 }
 
+fn emit_rerun_directives(crate_dir: &Path) -> Result<(), Box<dyn Error>> {
+    let build_script = crate_dir.join("build.rs");
+    println!("cargo:rerun-if-changed={}", build_script.display());
+
+    let manifest = crate_dir.join("Cargo.toml");
+    println!("cargo:rerun-if-changed={}", manifest.display());
+
+    emit_rerun_for_sources(&crate_dir.join("src"))?;
+
+    Ok(())
+}
+
+fn emit_rerun_for_sources(src_dir: &Path) -> Result<(), Box<dyn Error>> {
+    if !src_dir.exists() {
+        return Ok(());
+    }
+
+    let mut stack = vec![src_dir.to_path_buf()];
+    let mut files = Vec::new();
+
+    while let Some(dir) = stack.pop() {
+        for entry in fs::read_dir(&dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if entry.file_type()?.is_dir() {
+                stack.push(path);
+            } else if path.extension().map_or(false, |ext| ext == "rs") {
+                files.push(path);
+            }
+        }
+    }
+
+    files.sort();
+    for file in files {
+        println!("cargo:rerun-if-changed={}", file.display());
+    }
+
+    Ok(())
+}
+
 fn generate_header() -> Result<(), Box<dyn Error>> {
     let crate_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?);
-    println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rerun-if-changed=src/lib.rs");
-    println!("cargo:rerun-if-changed=Cargo.toml");
+    emit_rerun_directives(&crate_dir)?;
 
     let cbindgen_toml = crate_dir.join("cbindgen.toml");
     if cbindgen_toml.exists() {
@@ -237,10 +363,17 @@ fn generate_header() -> Result<(), Box<dyn Error>> {
     let bindings = Builder::new()
         .with_config(config)
         .with_crate(&crate_dir)
-        .generate()?;
+        .generate()
+        .map_err(|err| -> Box<dyn Error> {
+            Box::new(IoError::new(
+                ErrorKind::Other,
+                format!("cbindgen failed to generate bindings: {err}"),
+            ))
+        })?;
 
     let mut new_file_bytes = Vec::new();
     bindings.write(&mut new_file_bytes);
+
     if new_file_bytes.is_empty() {
         return Err(IoError::new(
             ErrorKind::Other,
@@ -250,6 +383,14 @@ fn generate_header() -> Result<(), Box<dyn Error>> {
         .into());
     }
     let new_contents = String::from_utf8(new_file_bytes)?;
+    if new_contents.trim().is_empty() {
+        return Err(IoError::new(
+            ErrorKind::Other,
+            "cbindgen produced an empty header; ensure FFI exports are marked #[no_mangle] and \
+             declared extern \"C\"",
+        )
+        .into());
+    }
 
     write_if_changed(&out_header_path, &new_contents)?;
 
@@ -272,9 +413,16 @@ fn generate_header() -> Result<(), Box<dyn Error>> {
 fn write_if_changed(path: &Path, contents: &str) -> Result<(), Box<dyn Error>> {
     let needs_write = match fs::read_to_string(path) {
         Ok(existing) => existing != contents,
-        Err(err) => match err.kind() {
-            ErrorKind::NotFound => true,
-            _ => return Err(err.into()),
+        Err(err) => {
+            if err.kind() == ErrorKind::NotFound {
+                true
+            } else {
+                return Err(IoError::new(
+                    err.kind(),
+                    format!("failed to read existing file {}: {err}", path.display()),
+                )
+                .into());
+            }
         },
     };
 
@@ -360,9 +508,10 @@ mod tests {
     }
 
     #[test]
-    fn allows_known_wrappers() {
+    fn allows_common_wrappers() {
         assert!(rustc_path_is_safe("/usr/bin/sccache"));
         assert!(rustc_path_is_safe("/usr/local/bin/rustc-wrapper"));
+        assert!(rustc_path_is_safe("ccache"));
     }
 
     #[test]
@@ -395,6 +544,31 @@ mod tests {
         assert!(!rustc_path_is_safe("/usr/bin/%2e%2e/sh"));
         assert!(!rustc_path_is_safe("%2E%2E/rustc"));
         assert!(!rustc_path_is_safe("rustc/%2e%2E/evil"));
+        assert!(!rustc_path_is_safe("/usr%2e%2e/bin/sh"));
+        assert!(!rustc_path_is_safe("path/to/..%2f../evil"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symlink_pointing_to_unexpected_binary() {
+        use std::os::unix::fs::symlink;
+
+        let temp_dir =
+            std::env::temp_dir().join(format!("mw_build_symlink_test_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&temp_dir);
+        fs::create_dir_all(&temp_dir).expect("failed to create symlink test dir");
+        let _guard = TempDirGuard(temp_dir.clone());
+
+        let target = temp_dir.join("not_rustc");
+        fs::write(&target, b"echo not rustc").expect("failed to create target file");
+        let link_path = temp_dir.join("rustc");
+        symlink(&target, &link_path).expect("failed to create symlink");
+
+        let link_str = link_path
+            .to_str()
+            .expect("symlink path not valid UTF-8")
+            .to_string();
+        assert!(!rustc_path_is_safe(&link_str));
     }
 
     #[test]

--- a/rust/unreal-bindings/build.rs
+++ b/rust/unreal-bindings/build.rs
@@ -123,16 +123,22 @@ mod security {
                 continue;
             }
 
-            let remaining = bytes.len() - index;
-            if remaining <= 2 {
+            let Some(high_index) = index.checked_add(1) else {
+                return true;
+            };
+            let Some(low_index) = index.checked_add(2) else {
+                return true;
+            };
+
+            if high_index >= bytes.len() || low_index >= bytes.len() {
                 return true;
             }
 
-            let high = match bytes.get(index + 1).copied().and_then(decode_hex_digit) {
+            let high = match bytes.get(high_index).copied().and_then(decode_hex_digit) {
                 Some(value) => value,
                 None => return true,
             };
-            let low = match bytes.get(index + 2).copied().and_then(decode_hex_digit) {
+            let low = match bytes.get(low_index).copied().and_then(decode_hex_digit) {
                 Some(value) => value,
                 None => return true,
             };
@@ -259,11 +265,18 @@ mod security {
             return is_allowed_compiler_name(rustc);
         }
 
-        let inspected_path = match fs::canonicalize(path) {
-            Ok(path) => path,
-            Err(_) if is_absolute_windows || is_unc => PathBuf::from(rustc),
+        let (inspected_path, canonicalized) = match fs::canonicalize(path) {
+            Ok(path) => (path, true),
+            Err(_) if is_absolute_windows || is_unc => (PathBuf::from(rustc), false),
             Err(_) => return false,
         };
+
+        if canonicalized {
+            match fs::metadata(&inspected_path) {
+                Ok(metadata) if metadata.is_file() => {},
+                _ => return false,
+            }
+        }
 
         if let Some(parent) = inspected_path.parent() {
             let parent_lower = parent.to_string_lossy().to_ascii_lowercase();
@@ -567,26 +580,32 @@ mod tests {
 
     use proptest::prelude::*;
 
-    const FORBIDDEN_SHELL_CHARS: &[char] = &[
-        ';', '&', '|', '`', '$', '>', '<', '\n', '\r', '\0', '\t', '"', '\'', '*', '?', '[', ']',
-        '{', '}', '(', ')', '~', '#', '!', '^', ' ',
-    ];
+    mod test_constants {
+        pub(super) const FORBIDDEN_SHELL_CHARS: &[char] = &[
+            ';', '&', '|', '`', '$', '>', '<', '\n', '\r', '\0', '\t', '"', '\'', '*', '?', '[',
+            ']', '{', '}', '(', ')', '~', '#', '!', '^', ' ',
+        ];
 
-    const ALLOWED_WRAPPER_NAMES: &[&str] =
-        &["rustc", "rustc.exe", "rustc-wrapper", "sccache", "ccache"];
+        pub(super) const ALLOWED_WRAPPER_NAMES: &[&str] =
+            &["rustc", "rustc.exe", "rustc-wrapper", "sccache", "ccache"];
 
-    const NON_HEX_CHARS: &[char] = &['g', 'G', 'z', 'Z', '/', ':', '-', '_'];
-    const SAFE_HEX_DIGITS: &[char] = &[
-        '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', 'A', 'B',
-        'C', 'D', 'E', 'F',
-    ];
+        pub(super) const NON_HEX_CHARS: &[char] = &['g', 'G', 'z', 'Z', '/', ':', '-', '_'];
+        pub(super) const SAFE_HEX_DIGITS: &[char] = &[
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', 'A',
+            'B', 'C', 'D', 'E', 'F',
+        ];
+    }
 
-    fn unique_temp_dir(prefix: &str) -> PathBuf {
-        let timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_nanos();
-        env::temp_dir().join(format!("{prefix}_{:x}_{:x}", std::process::id(), timestamp))
+    mod test_helpers {
+        use super::*;
+
+        pub(super) fn unique_temp_dir(prefix: &str) -> PathBuf {
+            let timestamp = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos();
+            env::temp_dir().join(format!("{prefix}_{:x}_{:x}", std::process::id(), timestamp))
+        }
     }
 
     mod rustc_path_validation {
@@ -611,7 +630,9 @@ mod tests {
 
         proptest! {
             #[test]
-            fn rejects_forbidden_shell_chars(ch in prop::sample::select(FORBIDDEN_SHELL_CHARS.to_vec())) {
+            fn rejects_forbidden_shell_chars(
+                ch in prop::sample::select(test_constants::FORBIDDEN_SHELL_CHARS.to_vec())
+            ) {
                 let candidate = format!("rustc{ch}payload");
                 prop_assert!(!rustc_path_is_safe(&candidate));
             }
@@ -626,7 +647,9 @@ mod tests {
 
         proptest! {
             #[test]
-            fn allows_known_wrapper_names(wrapper in prop::sample::select(ALLOWED_WRAPPER_NAMES.to_vec())) {
+            fn allows_known_wrapper_names(
+                wrapper in prop::sample::select(test_constants::ALLOWED_WRAPPER_NAMES.to_vec())
+            ) {
                 prop_assert!(rustc_path_is_safe(wrapper));
             }
         }
@@ -686,7 +709,10 @@ mod tests {
 
         proptest! {
             #[test]
-            fn rejects_non_hex_percent_sequences(high in prop::sample::select(NON_HEX_CHARS.to_vec()), low in prop::sample::select(NON_HEX_CHARS.to_vec())) {
+            fn rejects_non_hex_percent_sequences(
+                high in prop::sample::select(test_constants::NON_HEX_CHARS.to_vec()),
+                low in prop::sample::select(test_constants::NON_HEX_CHARS.to_vec())
+            ) {
                 let candidate = format!("%{high}{low}");
                 prop_assert!(security::contains_forbidden_percent_encoding_public(&candidate));
             }
@@ -694,7 +720,7 @@ mod tests {
 
         #[test]
         fn allows_harmless_percent_sequences() {
-            let base = unique_temp_dir("mw_percent_test");
+            let base = test_helpers::unique_temp_dir("mw_percent_test");
             let cargo_bin = base.join(".cargo/bin");
             fs::create_dir_all(&cargo_bin).expect("failed to create cargo bin directory");
             let _guard = super::file_operations::TempDirGuard(base.clone());
@@ -712,8 +738,8 @@ mod tests {
         proptest! {
             #[test]
             fn allows_safe_percent_sequences(
-                high in prop::sample::select(SAFE_HEX_DIGITS.to_vec()),
-                low in prop::sample::select(SAFE_HEX_DIGITS.to_vec()),
+                high in prop::sample::select(test_constants::SAFE_HEX_DIGITS.to_vec()),
+                low in prop::sample::select(test_constants::SAFE_HEX_DIGITS.to_vec()),
             ) {
                 let pair = format!("{high}{low}");
                 if let Ok(decoded) = u8::from_str_radix(&pair, 16) {
@@ -730,7 +756,7 @@ mod tests {
         fn rejects_symlink_pointing_to_unexpected_binary() {
             use std::os::unix::fs::symlink;
 
-            let temp_dir = unique_temp_dir("mw_build_symlink_test");
+            let temp_dir = test_helpers::unique_temp_dir("mw_build_symlink_test");
             let _ = fs::remove_dir_all(&temp_dir);
             fs::create_dir_all(&temp_dir).expect("failed to create symlink test dir");
             let _guard = super::file_operations::TempDirGuard(temp_dir.clone());
@@ -795,7 +821,7 @@ mod tests {
 
         #[test]
         fn enforces_directory_allowlist() {
-            let allowed_root = unique_temp_dir("mw_allowlist_ok");
+            let allowed_root = test_helpers::unique_temp_dir("mw_allowlist_ok");
             let allowed_bin = allowed_root.join(".cargo/bin");
             fs::create_dir_all(&allowed_bin).expect("failed to create allowed bin directory");
             let allowed_guard = super::file_operations::TempDirGuard(allowed_root.clone());
@@ -808,7 +834,7 @@ mod tests {
             assert!(rustc_path_is_safe(&allowed_str));
             drop(allowed_guard);
 
-            let disallowed_root = unique_temp_dir("mw_allowlist_blocked");
+            let disallowed_root = test_helpers::unique_temp_dir("mw_allowlist_blocked");
             fs::create_dir_all(&disallowed_root).expect("failed to create disallowed dir");
             let _disallowed_guard = super::file_operations::TempDirGuard(disallowed_root.clone());
             let disallowed_path = disallowed_root.join("rustc");

--- a/rust/unreal-bindings/src/security.rs
+++ b/rust/unreal-bindings/src/security.rs
@@ -1,0 +1,520 @@
+use std::{
+    fs::{self, Metadata},
+    path::{Component, Path, PathBuf},
+};
+
+use super::RUSTC_PATH_LENGTH_LIMIT;
+
+const ALLOWED_HIDDEN_COMPONENTS: &[&str] = &[".cargo", ".rustup"];
+
+fn decode_hex_digit(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn contains_forbidden_percent_encoding(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    let mut index = 0;
+
+    while index < bytes.len() {
+        if bytes[index] != b'%' {
+            index += 1;
+            continue;
+        }
+
+        let Some(high_index) = index.checked_add(1) else {
+            return true;
+        };
+        let Some(low_index) = index.checked_add(2) else {
+            return true;
+        };
+
+        if high_index >= bytes.len() || low_index >= bytes.len() {
+            return true;
+        }
+
+        let high = match bytes.get(high_index).copied().and_then(decode_hex_digit) {
+            Some(value) => value,
+            None => return true,
+        };
+        let low = match bytes.get(low_index).copied().and_then(decode_hex_digit) {
+            Some(value) => value,
+            None => return true,
+        };
+        let decoded = (high << 4) | low;
+
+        match decoded {
+            b'.' | b'/' | b'\\' | b' ' | b'\t' | b'\n' | b'\r' => return true,
+            _ => {},
+        }
+
+        index += 3;
+    }
+
+    false
+}
+
+fn has_suspicious_component(path: &Path) -> bool {
+    for component in path.components() {
+        match component {
+            Component::ParentDir | Component::CurDir => return true,
+            Component::Normal(segment) => {
+                let segment = segment.to_string_lossy();
+                if segment.is_empty() {
+                    return true;
+                }
+
+                let lower = segment.to_ascii_lowercase();
+                if lower.starts_with('.')
+                    && !ALLOWED_HIDDEN_COMPONENTS
+                        .iter()
+                        .any(|allowed| lower == *allowed)
+                {
+                    return true;
+                }
+
+                if lower == "" || lower == "~" {
+                    return true;
+                }
+            },
+            _ => {},
+        }
+    }
+
+    false
+}
+
+fn is_allowed_compiler_name(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+
+    matches!(
+        lower.as_str(),
+        "rustc"
+            | "rustc.exe"
+            | "rustc.bat"
+            | "rustc.cmd"
+            | "rustc_driver"
+            | "rustc_driver.exe"
+            | "rustc-wrapper"
+            | "rustc-wrapper.exe"
+            | "sccache"
+            | "sccache.exe"
+            | "ccache"
+            | "ccache.exe"
+    ) || lower.starts_with("rustc-")
+        || lower.starts_with("rustc_")
+}
+
+fn metadata_for(path: &Path) -> Option<Metadata> {
+    match fs::metadata(path) {
+        Ok(meta) => Some(meta),
+        Err(_) => None,
+    }
+}
+
+/// Evaluate whether a provided `rustc` executable path is considered safe to
+/// execute.
+///
+/// The validator aggressively rejects obvious command-injection vectors,
+/// percent-encoded traversal attempts, canonicalised paths that escape a
+/// curated allowlist of toolchain directories, and executables with unsafe
+/// permissions. Canonicalisation is only used to reduce symlink and traversal
+/// risks; the build immediately hands off to Cargo after validation to avoid
+/// extending the TOCTOU window.
+pub(crate) fn rustc_path_is_safe(rustc: &str) -> bool {
+    if rustc.is_empty() || rustc.len() >= RUSTC_PATH_LENGTH_LIMIT {
+        return false;
+    }
+
+    if rustc.chars().any(|ch| {
+        matches!(
+            ch,
+            ';' | '&'
+                | '|'
+                | '`'
+                | '$'
+                | '>'
+                | '<'
+                | '\n'
+                | '\r'
+                | '\0'
+                | '\t'
+                | '"'
+                | '\''
+                | '*'
+                | '?'
+                | '['
+                | ']'
+                | '{'
+                | '}'
+                | '('
+                | ')'
+                | '~'
+                | '#'
+                | '!'
+                | '^'
+                | ' '
+        )
+    }) {
+        return false;
+    }
+
+    if rustc.contains("..") || contains_forbidden_percent_encoding(rustc) {
+        return false;
+    }
+
+    if rustc.starts_with('-') {
+        return false;
+    }
+
+    let path = Path::new(rustc);
+    if has_suspicious_component(path) {
+        return false;
+    }
+
+    let is_simple = !rustc.contains('/') && !rustc.contains('\\');
+    let bytes = rustc.as_bytes();
+    let is_absolute_unix = rustc.starts_with('/');
+    let is_absolute_windows = bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && matches!(bytes[2], b'/' | b'\\');
+    let is_unc = if bytes.len() >= 5 && bytes[0] == b'\\' && bytes[1] == b'\\' {
+        let third = bytes[2];
+        third != b'\\' && third != b'/' && bytes[2..].contains(&b'\\')
+    } else {
+        false
+    };
+
+    if !(is_simple || is_absolute_unix || is_absolute_windows || is_unc) {
+        return false;
+    }
+
+    if is_simple && rustc.contains(':') {
+        return false;
+    }
+
+    if is_simple {
+        return is_allowed_compiler_name(rustc);
+    }
+
+    if !path.exists() {
+        return false;
+    }
+
+    let (inspected_path, canonicalized) = match fs::canonicalize(path) {
+        Ok(path) => (path, true),
+        Err(_) if is_absolute_windows || is_unc => (PathBuf::from(rustc), false),
+        Err(_) => return false,
+    };
+
+    if has_suspicious_component(&inspected_path) {
+        return false;
+    }
+
+    let metadata = if canonicalized {
+        match metadata_for(&inspected_path) {
+            Some(meta) => meta,
+            None => return false,
+        }
+    } else {
+        match metadata_for(&inspected_path).or_else(|| metadata_for(path)) {
+            Some(meta) => meta,
+            None => return false,
+        }
+    };
+
+    if !metadata.is_file() {
+        return false;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        const WORLD_WRITABLE: u32 = 0o002;
+        if metadata.permissions().mode() & WORLD_WRITABLE != 0 {
+            return false;
+        }
+    }
+
+    if let Some(parent) = inspected_path.parent() {
+        let parent_lower = parent.to_string_lossy().to_ascii_lowercase();
+        const ALLOWED_PREFIXES: &[&str] = &[
+            "/usr/bin",
+            "/usr/local/bin",
+            "/opt/",
+            "c:/rust",
+            "c:/program files",
+            "c:/users",
+            "c\\rust",
+            "c\\program files",
+            "c\\users",
+        ];
+
+        let allowed = parent_lower.starts_with("\\\\")
+            || ALLOWED_PREFIXES
+                .iter()
+                .any(|prefix| parent_lower.starts_with(prefix))
+            || parent_lower.contains("/.cargo/bin")
+            || parent_lower.contains("\\.cargo\\bin")
+            || parent_lower.contains("/.rustup/toolchains")
+            || parent_lower.contains("\\.rustup\\toolchains")
+            || parent_lower.contains("program files");
+
+        if !allowed {
+            return false;
+        }
+    }
+
+    let file_name = inspected_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| name.to_ascii_lowercase());
+
+    match file_name.as_deref() {
+        Some(name) if is_allowed_compiler_name(name) => true,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn contains_forbidden_percent_encoding_public(value: &str) -> bool {
+    contains_forbidden_percent_encoding(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    use std::{
+        env, fs,
+        io::Write,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    mod constants {
+        pub(super) const FORBIDDEN_SHELL_CHARS: &[char] = &[
+            ';', '&', '|', '`', '$', '>', '<', '\n', '\r', '\0', '\t', '"', '\'', '*', '?', '[',
+            ']', '{', '}', '(', ')', '~', '#', '!', '^', ' ',
+        ];
+        pub(super) const NON_HEX_CHARS: &[char] = &['g', 'G', 'z', 'Z', '/', ':', '-', '_'];
+        pub(super) const SAFE_HEX_DIGITS: &[char] = &[
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', 'A',
+            'B', 'C', 'D', 'E', 'F',
+        ];
+        pub(super) const ALLOWED_WRAPPER_NAMES: &[&str] =
+            &["rustc", "rustc.exe", "rustc-wrapper", "sccache", "ccache"];
+    }
+
+    mod helpers {
+        use super::*;
+
+        pub(super) struct TempDirGuard(pub(super) PathBuf);
+
+        impl Drop for TempDirGuard {
+            fn drop(&mut self) { let _ = fs::remove_dir_all(&self.0); }
+        }
+
+        pub(super) fn unique_temp_dir(prefix: &str) -> PathBuf {
+            let timestamp = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos();
+            let path =
+                env::temp_dir().join(format!("{prefix}_{:x}_{:x}", std::process::id(), timestamp));
+            let _ = fs::create_dir_all(&path);
+            path
+        }
+
+        pub(super) fn create_tool(path: &Path, contents: &[u8]) {
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).expect("failed to create parent directory");
+            }
+            let mut file = fs::File::create(path).expect("failed to create tool");
+            file.write_all(contents)
+                .expect("failed to write tool contents");
+        }
+    }
+
+    use helpers::{TempDirGuard, create_tool, unique_temp_dir};
+
+    #[test]
+    fn rejects_shell_metacharacters() {
+        for ch in constants::FORBIDDEN_SHELL_CHARS {
+            let candidate = format!("rustc{ch}");
+            assert!(!rustc_path_is_safe(&candidate));
+        }
+    }
+
+    #[test]
+    fn rejects_path_component_tricks() {
+        assert!(!rustc_path_is_safe("./rustc"));
+        assert!(!rustc_path_is_safe("../rustc"));
+        assert!(!rustc_path_is_safe("rustc/../bin"));
+        assert!(!rustc_path_is_safe("/usr/bin/.hidden/rustc"));
+    }
+
+    #[test]
+    fn rejects_nonexistent_paths() {
+        let base = unique_temp_dir("mw_missing_tool");
+        let _guard = TempDirGuard(base.clone());
+        let missing = base.join("rustc");
+        assert!(!rustc_path_is_safe(missing.to_str().unwrap()));
+    }
+
+    #[test]
+    fn rejects_url_encoded_path_traversal() {
+        assert!(!rustc_path_is_safe("/usr/bin/%2e%2e/sh"));
+        assert!(!rustc_path_is_safe("%2E%2E/rustc"));
+        assert!(!rustc_path_is_safe("rustc/%2e%2E/evil"));
+        assert!(!rustc_path_is_safe("/usr%2e%2e/bin/sh"));
+        assert!(!rustc_path_is_safe("path/to/..%2f../evil"));
+    }
+
+    #[test]
+    fn rejects_malformed_percent_sequences() {
+        assert!(!rustc_path_is_safe("rustc%"));
+        assert!(!rustc_path_is_safe("rustc%2"));
+        assert!(!rustc_path_is_safe("rustc%2G"));
+        assert!(!rustc_path_is_safe("%"));
+    }
+
+    #[test]
+    fn rejects_incomplete_percent_at_end() {
+        assert!(contains_forbidden_percent_encoding_public("%"));
+        assert!(contains_forbidden_percent_encoding_public("rustc%"));
+        assert!(contains_forbidden_percent_encoding_public("rustc%2"));
+    }
+
+    #[test]
+    fn allows_harmless_percent_sequences() {
+        let base = unique_temp_dir("mw_percent_test");
+        let cargo_bin = base.join(".cargo/bin");
+        let _guard = TempDirGuard(base.clone());
+
+        let tool_path = cargo_bin.join("rustc%41");
+        create_tool(&tool_path, b"#!/bin/true\n");
+
+        let tool_str = tool_path
+            .to_str()
+            .expect("path not valid UTF-8")
+            .to_string();
+        assert!(rustc_path_is_safe(&tool_str));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_world_writable_compiler() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let base = unique_temp_dir("mw_world_writable");
+        let cargo_bin = base.join(".cargo/bin");
+        let _guard = TempDirGuard(base.clone());
+
+        let tool_path = cargo_bin.join("rustc");
+        create_tool(&tool_path, b"#!/bin/true\n");
+
+        let mut perms = fs::metadata(&tool_path).expect("metadata").permissions();
+        perms.set_mode(0o777);
+        fs::set_permissions(&tool_path, perms).expect("failed to update perms");
+
+        let tool_str = tool_path.to_str().unwrap().to_string();
+        assert!(!rustc_path_is_safe(&tool_str));
+    }
+
+    #[test]
+    fn enforces_directory_allowlist() {
+        let allowed_root = unique_temp_dir("mw_allowlist_ok");
+        let allowed_bin = allowed_root.join(".cargo/bin");
+        let allowed_guard = TempDirGuard(allowed_root.clone());
+        let allowed_path = allowed_bin.join("rustc");
+        create_tool(&allowed_path, b"#!/bin/true\n");
+        let allowed_str = allowed_path.to_str().unwrap().to_string();
+        assert!(rustc_path_is_safe(&allowed_str));
+        drop(allowed_guard);
+
+        let disallowed_root = unique_temp_dir("mw_allowlist_blocked");
+        let disallowed_guard = TempDirGuard(disallowed_root.clone());
+        let disallowed_path = disallowed_root.join("rustc");
+        create_tool(&disallowed_path, b"#!/bin/true\n");
+        let disallowed_str = disallowed_path.to_str().unwrap().to_string();
+        assert!(!rustc_path_is_safe(&disallowed_str));
+        drop(disallowed_guard);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symlink_pointing_to_unexpected_binary() {
+        use std::os::unix::fs::symlink;
+
+        let temp_dir = unique_temp_dir("mw_build_symlink_test");
+        let _guard = TempDirGuard(temp_dir.clone());
+
+        let target = temp_dir.join("not_rustc");
+        create_tool(&target, b"echo not rustc\n");
+        let link_path = temp_dir.join("rustc");
+        symlink(&target, &link_path).expect("failed to create symlink");
+
+        let link_str = link_path.to_str().unwrap().to_string();
+        assert!(!rustc_path_is_safe(&link_str));
+    }
+
+    proptest! {
+        #[test]
+        fn rejects_non_hex_percent_sequences(
+            high in prop::sample::select(constants::NON_HEX_CHARS.to_vec()),
+            low in prop::sample::select(constants::NON_HEX_CHARS.to_vec())
+        ) {
+            let candidate = format!("%{high}{low}");
+            prop_assert!(contains_forbidden_percent_encoding_public(&candidate));
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn allows_safe_percent_sequences(
+            high in prop::sample::select(constants::SAFE_HEX_DIGITS.to_vec()),
+            low in prop::sample::select(constants::SAFE_HEX_DIGITS.to_vec()),
+        ) {
+            let pair = format!("{high}{low}");
+            if let Ok(decoded) = u8::from_str_radix(&pair, 16) {
+                prop_assume!(!matches!(decoded, b'.' | b'/' | b'\\' | b' ' | b'\t' | b'\n' | b'\r'));
+
+                let candidate = format!("/usr/local/bin/rustc%{pair}");
+                prop_assert!(rustc_path_is_safe(&candidate));
+            }
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn accepts_windows_backslash_paths() {
+        assert!(rustc_path_is_safe(r"C:\\Rust\\bin\\rustc.exe"));
+        assert!(rustc_path_is_safe(r"\\\\server\\share\\rustc.exe"));
+    }
+
+    #[test]
+    fn distinguishes_absolute_simple_and_relative_paths() {
+        assert!(rustc_path_is_safe("rustc"));
+        assert!(rustc_path_is_safe("/usr/bin/rustc"));
+        assert!(!rustc_path_is_safe("bin/rustc"));
+        assert!(!rustc_path_is_safe(r".\\rustc.exe"));
+    }
+
+    #[test]
+    fn rejects_flag_injection() {
+        assert!(!rustc_path_is_safe("-Zprint-link-args"));
+        assert!(!rustc_path_is_safe("--help"));
+    }
+
+    #[test]
+    fn rejects_oversized_paths() {
+        let oversized = "a".repeat(RUSTC_PATH_LENGTH_LIMIT + 1);
+        assert!(!rustc_path_is_safe(&oversized));
+    }
+}

--- a/rust/unreal-bindings/src/security.rs
+++ b/rust/unreal-bindings/src/security.rs
@@ -2,9 +2,28 @@
 //! binaries from the build script. The routines deliberately fail closed when
 //! encountering ambiguous filesystem state to minimise the risk of command
 //! injection or traversal attacks.
+//!
+//! # Security Model
+//!
+//! This module implements defence-in-depth validation for `rustc` executable
+//! paths to mitigate:
+//!
+//! - **Command injection:** shell metacharacters are rejected before spawning
+//!   the compiler.
+//! - **Path traversal:** plain and percent-encoded traversal attempts are
+//!   blocked prior to canonicalisation.
+//! - **Symlink manipulation:** canonicalisation combined with component checks
+//!   prevents chaining through hostile symlinks.
+//! - **Permission escalation:** world-writable executables are disallowed on
+//!   Unix hosts to prevent privilege downgrades.
+//! - **Directory escapes:** canonicalised paths must reside under an
+//!   allowlisted toolchain directory.
+//!
+//! Validation prioritises safety over convenience. Any ambiguous or malformed
+//! input causes the function to fail closed instead of emitting warnings.
 
 use std::{
-    fs::{self, Metadata},
+    fs,
     path::{Component, Path, PathBuf},
 };
 
@@ -116,24 +135,16 @@ fn is_allowed_compiler_name(value: &str) -> bool {
         || lower.starts_with("rustc_")
 }
 
-fn metadata_for(path: &Path) -> Option<Metadata> {
-    match fs::metadata(path) {
-        Ok(meta) => Some(meta),
-        Err(_) => None,
-    }
-}
-
-/// Evaluate whether a provided `rustc` executable path is considered safe to
-/// execute.
-///
-/// The validator aggressively rejects obvious command-injection vectors,
-/// percent-encoded traversal attempts, canonicalised paths that escape a
-/// curated allowlist of toolchain directories, and executables with unsafe
-/// permissions. Canonicalisation is only used to reduce symlink and traversal
-/// risks; the build immediately hands off to Cargo after validation to avoid
-/// extending the TOCTOU window.
-pub(crate) fn rustc_path_is_safe(rustc: &str) -> bool {
+fn validate_basic_path_constraints(rustc: &str) -> bool {
     if rustc.is_empty() || rustc.len() >= RUSTC_PATH_LENGTH_LIMIT {
+        return false;
+    }
+
+    if rustc.starts_with('-') {
+        return false;
+    }
+
+    if rustc.contains("..") || contains_forbidden_percent_encoding(rustc) {
         return false;
     }
 
@@ -170,11 +181,20 @@ pub(crate) fn rustc_path_is_safe(rustc: &str) -> bool {
         return false;
     }
 
-    if rustc.contains("..") || contains_forbidden_percent_encoding(rustc) {
-        return false;
-    }
+    true
+}
 
-    if rustc.starts_with('-') {
+/// Evaluate whether a provided `rustc` executable path is considered safe to
+/// execute.
+///
+/// The validator aggressively rejects obvious command-injection vectors,
+/// percent-encoded traversal attempts, canonicalised paths that escape a
+/// curated allowlist of toolchain directories, and executables with unsafe
+/// permissions. Canonicalisation is only used to reduce symlink and traversal
+/// risks; the build immediately hands off to Cargo after validation to avoid
+/// extending the TOCTOU window.
+pub(crate) fn rustc_path_is_safe(rustc: &str) -> bool {
+    if !validate_basic_path_constraints(rustc) {
         return false;
     }
 
@@ -209,20 +229,16 @@ pub(crate) fn rustc_path_is_safe(rustc: &str) -> bool {
         return is_allowed_compiler_name(rustc);
     }
 
-    if !path.exists() {
-        return false;
-    }
-
     let (inspected_path, metadata) = match fs::canonicalize(path) {
-        Ok(canonical) => match metadata_for(&canonical) {
-            Some(meta) => (canonical, meta),
-            None => return false,
+        Ok(canonical) => match fs::metadata(&canonical) {
+            Ok(meta) => (canonical, meta),
+            Err(_) => return false,
         },
         Err(_) if is_absolute_windows || is_unc => {
             let fallback = PathBuf::from(rustc);
-            match metadata_for(&fallback).or_else(|| metadata_for(path)) {
-                Some(meta) => (fallback, meta),
-                None => return false,
+            match fs::metadata(&fallback).or_else(|_| fs::metadata(path)) {
+                Ok(meta) => (fallback, meta),
+                Err(_) => return false,
             }
         },
         Err(_) => return false,
@@ -246,19 +262,38 @@ pub(crate) fn rustc_path_is_safe(rustc: &str) -> bool {
     }
 
     if let Some(parent) = inspected_path.parent() {
-        let parent_lower = parent.to_string_lossy().to_ascii_lowercase();
-        let allowed = parent_lower.starts_with("\\\\")
-            || ALLOWED_PARENT_PREFIXES
-                .iter()
-                .any(|prefix| parent_lower.starts_with(prefix))
-            || parent_lower.contains("/.cargo/bin")
-            || parent_lower.contains("\\.cargo\\bin")
-            || parent_lower.contains("/.rustup/toolchains")
-            || parent_lower.contains("\\.rustup\\toolchains")
-            || parent_lower.contains("program files");
+        let mut allowed = false;
+
+        if let Some(parent_str) = parent.to_str() {
+            if parent_str.starts_with("\\\\") {
+                allowed = true;
+            } else {
+                let parent_lower = parent_str.to_ascii_lowercase();
+                allowed = ALLOWED_PARENT_PREFIXES
+                    .iter()
+                    .any(|prefix| parent_lower.starts_with(prefix))
+                    || parent_lower.contains("/.cargo/bin")
+                    || parent_lower.contains("\\.cargo\\bin")
+                    || parent_lower.contains("/.rustup/toolchains")
+                    || parent_lower.contains("\\.rustup\\toolchains")
+                    || parent_lower.contains("program files");
+            }
+        }
 
         if !allowed {
-            return false;
+            let parent_lower = parent.to_string_lossy().to_ascii_lowercase();
+            if !(parent_lower.starts_with("\\\\")
+                || ALLOWED_PARENT_PREFIXES
+                    .iter()
+                    .any(|prefix| parent_lower.starts_with(prefix))
+                || parent_lower.contains("/.cargo/bin")
+                || parent_lower.contains("\\.cargo\\bin")
+                || parent_lower.contains("/.rustup/toolchains")
+                || parent_lower.contains("\\.rustup\\toolchains")
+                || parent_lower.contains("program files"))
+            {
+                return false;
+            }
         }
     }
 
@@ -335,11 +370,33 @@ mod tests {
     use helpers::{TempDirGuard, create_tool, unique_temp_dir};
 
     #[test]
+    fn validate_basic_path_constraints_rejects_invalid_paths() {
+        assert!(!validate_basic_path_constraints(""));
+        assert!(!validate_basic_path_constraints(
+            &"a".repeat(RUSTC_PATH_LENGTH_LIMIT + 1)
+        ));
+        assert!(!validate_basic_path_constraints("../rustc"));
+        assert!(!validate_basic_path_constraints("-Zunstable-options"));
+    }
+
+    #[test]
     fn rejects_shell_metacharacters() {
         for ch in constants::FORBIDDEN_SHELL_CHARS {
             let candidate = format!("rustc{ch}");
             assert!(!rustc_path_is_safe(&candidate));
         }
+    }
+
+    #[test]
+    fn test_validates_metadata_atomically() {
+        let base = unique_temp_dir("mw_metadata_atomic");
+        let guard = TempDirGuard(base.clone());
+        let dir_path = base.join(".cargo/bin/rustc");
+        fs::create_dir_all(&dir_path).expect("failed to create test directory");
+
+        let dir_str = dir_path.to_str().expect("path not utf-8").to_string();
+        assert!(!rustc_path_is_safe(&dir_str));
+        drop(guard);
     }
 
     #[test]
@@ -463,6 +520,46 @@ mod tests {
         ) {
             let candidate = format!("%{high}{low}");
             prop_assert!(contains_forbidden_percent_encoding_public(&candidate));
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn rejects_all_forbidden_encoded_chars(
+            prefix in "[a-zA-Z0-9_-]{0,10}",
+            forbidden_char in prop::sample::select(vec![b'.', b'/', b'\\', b' ', b'\t', b'\n', b'\r']),
+            suffix in "[a-zA-Z0-9_-]{0,10}"
+        ) {
+            let encoded = format!("{prefix}%{:02X}{suffix}", forbidden_char);
+            prop_assert!(contains_forbidden_percent_encoding_public(&encoded));
+
+            let encoded_lower = format!("{prefix}%{:02x}{suffix}", forbidden_char);
+            prop_assert!(contains_forbidden_percent_encoding_public(&encoded_lower));
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn handles_malformed_sequences_consistently(
+            base in "[a-zA-Z0-9/]{1,20}",
+            malformed in prop::sample::select(vec!["%", "%G", "%2G", "%GG", "%%"])
+        ) {
+            let candidate = format!("{base}{malformed}");
+            prop_assert!(contains_forbidden_percent_encoding_public(&candidate));
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn path_length_boundary_validation(
+            base_len in 1..=(RUSTC_PATH_LENGTH_LIMIT - 10),
+            extra_chars in 1..=20usize
+        ) {
+            let short_path = "a".repeat(base_len);
+            prop_assert!(validate_basic_path_constraints(&short_path));
+
+            let long_path = "a".repeat(RUSTC_PATH_LENGTH_LIMIT + extra_chars);
+            prop_assert!(!validate_basic_path_constraints(&long_path));
         }
     }
 

--- a/rust/unreal-bindings/src/security.rs
+++ b/rust/unreal-bindings/src/security.rs
@@ -39,9 +39,6 @@ const ALLOWED_PARENT_PREFIXES: &[&str] = &[
     "c:/rust",
     "c:/program files",
     "c:/users",
-    "c\\rust",
-    "c\\program files",
-    "c\\users",
 ];
 
 #[cfg(unix)]
@@ -103,7 +100,7 @@ fn has_suspicious_component(path: &Path) -> bool {
                     return true;
                 }
 
-                if lower == "" || lower == "~" {
+                if lower == "~" {
                     return true;
                 }
             },
@@ -236,7 +233,7 @@ pub(crate) fn rustc_path_is_safe(rustc: &str) -> bool {
         },
         Err(_) if is_absolute_windows || is_unc => {
             let fallback = PathBuf::from(rustc);
-            match fs::metadata(&fallback).or_else(|_| fs::metadata(path)) {
+            match fs::metadata(&fallback) {
                 Ok(meta) => (fallback, meta),
                 Err(_) => return false,
             }
@@ -262,38 +259,19 @@ pub(crate) fn rustc_path_is_safe(rustc: &str) -> bool {
     }
 
     if let Some(parent) = inspected_path.parent() {
-        let mut allowed = false;
+        let parent_lower = parent.to_string_lossy().to_ascii_lowercase();
+        let normalized = parent_lower.replace('\\', "/");
 
-        if let Some(parent_str) = parent.to_str() {
-            if parent_str.starts_with("\\\\") {
-                allowed = true;
-            } else {
-                let parent_lower = parent_str.to_ascii_lowercase();
-                allowed = ALLOWED_PARENT_PREFIXES
-                    .iter()
-                    .any(|prefix| parent_lower.starts_with(prefix))
-                    || parent_lower.contains("/.cargo/bin")
-                    || parent_lower.contains("\\.cargo\\bin")
-                    || parent_lower.contains("/.rustup/toolchains")
-                    || parent_lower.contains("\\.rustup\\toolchains")
-                    || parent_lower.contains("program files");
-            }
-        }
+        let allowed = parent_lower.starts_with("\\\\")
+            || ALLOWED_PARENT_PREFIXES
+                .iter()
+                .any(|prefix| normalized.starts_with(prefix))
+            || normalized.contains("/.cargo/bin")
+            || normalized.contains("/.rustup/toolchains")
+            || parent_lower.contains("program files");
 
         if !allowed {
-            let parent_lower = parent.to_string_lossy().to_ascii_lowercase();
-            if !(parent_lower.starts_with("\\\\")
-                || ALLOWED_PARENT_PREFIXES
-                    .iter()
-                    .any(|prefix| parent_lower.starts_with(prefix))
-                || parent_lower.contains("/.cargo/bin")
-                || parent_lower.contains("\\.cargo\\bin")
-                || parent_lower.contains("/.rustup/toolchains")
-                || parent_lower.contains("\\.rustup\\toolchains")
-                || parent_lower.contains("program files"))
-            {
-                return false;
-            }
+            return false;
         }
     }
 
@@ -405,6 +383,8 @@ mod tests {
         assert!(!rustc_path_is_safe("../rustc"));
         assert!(!rustc_path_is_safe("rustc/../bin"));
         assert!(!rustc_path_is_safe("/usr/bin/.hidden/rustc"));
+        assert!(!rustc_path_is_safe("c:/rust/../evil"));
+        assert!(!rustc_path_is_safe("c\\rust\\..\\evil"));
     }
 
     #[test]
@@ -501,11 +481,12 @@ mod tests {
         use std::os::unix::fs::symlink;
 
         let temp_dir = unique_temp_dir("mw_build_symlink_test");
+        let cargo_bin = temp_dir.join(".cargo/bin");
         let _guard = TempDirGuard(temp_dir.clone());
 
-        let target = temp_dir.join("not_rustc");
+        let target = cargo_bin.join("not_rustc");
         create_tool(&target, b"echo not rustc\n");
-        let link_path = temp_dir.join("rustc");
+        let link_path = cargo_bin.join("rustc");
         symlink(&target, &link_path).expect("failed to create symlink");
 
         let link_str = link_path.to_str().unwrap().to_string();
@@ -573,7 +554,14 @@ mod tests {
             if let Ok(decoded) = u8::from_str_radix(&pair, 16) {
                 prop_assume!(!matches!(decoded, b'.' | b'/' | b'\\' | b' ' | b'\t' | b'\n' | b'\r'));
 
-                let candidate = format!("/usr/local/bin/rustc%{pair}");
+                let base = unique_temp_dir("mw_prop_percent");
+                let cargo_bin = base.join(".cargo/bin");
+                let _guard = TempDirGuard(base.clone());
+
+                let candidate_path = cargo_bin.join(format!("rustc%{pair}"));
+                create_tool(&candidate_path, b"#!/bin/true\n");
+
+                let candidate = candidate_path.to_str().unwrap().to_string();
                 prop_assert!(rustc_path_is_safe(&candidate));
             }
         }

--- a/rust/unreal-bindings/src/security.rs
+++ b/rust/unreal-bindings/src/security.rs
@@ -1,3 +1,8 @@
+//! Hardened validation helpers that gate execution of external toolchain
+//! binaries from the build script. The routines deliberately fail closed when
+//! encountering ambiguous filesystem state to minimise the risk of command
+//! injection or traversal attacks.
+
 use std::{
     fs::{self, Metadata},
     path::{Component, Path, PathBuf},
@@ -6,6 +11,22 @@ use std::{
 use super::RUSTC_PATH_LENGTH_LIMIT;
 
 const ALLOWED_HIDDEN_COMPONENTS: &[&str] = &[".cargo", ".rustup"];
+const MIN_WINDOWS_ABSOLUTE_LENGTH: usize = 3;
+const MIN_UNC_PATH_LENGTH: usize = 5;
+const ALLOWED_PARENT_PREFIXES: &[&str] = &[
+    "/usr/bin",
+    "/usr/local/bin",
+    "/opt/",
+    "c:/rust",
+    "c:/program files",
+    "c:/users",
+    "c\\rust",
+    "c\\program files",
+    "c\\users",
+];
+
+#[cfg(unix)]
+const WORLD_WRITABLE_MASK: u32 = 0o002;
 
 fn decode_hex_digit(byte: u8) -> Option<u8> {
     match byte {
@@ -20,36 +41,22 @@ fn contains_forbidden_percent_encoding(value: &str) -> bool {
     let bytes = value.as_bytes();
     let mut index = 0;
 
-    while index < bytes.len() {
-        if bytes[index] != b'%' {
+    while let Some(&byte) = bytes.get(index) {
+        if byte != b'%' {
             index += 1;
             continue;
         }
 
-        let Some(high_index) = index.checked_add(1) else {
-            return true;
-        };
-        let Some(low_index) = index.checked_add(2) else {
-            return true;
+        let decoded = match (bytes.get(index + 1), bytes.get(index + 2)) {
+            (Some(&high), Some(&low)) => match (decode_hex_digit(high), decode_hex_digit(low)) {
+                (Some(high), Some(low)) => (high << 4) | low,
+                _ => return true,
+            },
+            _ => return true,
         };
 
-        if high_index >= bytes.len() || low_index >= bytes.len() {
+        if matches!(decoded, b'.' | b'/' | b'\\' | b' ' | b'\t' | b'\n' | b'\r') {
             return true;
-        }
-
-        let high = match bytes.get(high_index).copied().and_then(decode_hex_digit) {
-            Some(value) => value,
-            None => return true,
-        };
-        let low = match bytes.get(low_index).copied().and_then(decode_hex_digit) {
-            Some(value) => value,
-            None => return true,
-        };
-        let decoded = (high << 4) | low;
-
-        match decoded {
-            b'.' | b'/' | b'\\' | b' ' | b'\t' | b'\n' | b'\r' => return true,
-            _ => {},
         }
 
         index += 3;
@@ -179,11 +186,11 @@ pub(crate) fn rustc_path_is_safe(rustc: &str) -> bool {
     let is_simple = !rustc.contains('/') && !rustc.contains('\\');
     let bytes = rustc.as_bytes();
     let is_absolute_unix = rustc.starts_with('/');
-    let is_absolute_windows = bytes.len() >= 3
+    let is_absolute_windows = bytes.len() >= MIN_WINDOWS_ABSOLUTE_LENGTH
         && bytes[0].is_ascii_alphabetic()
         && bytes[1] == b':'
         && matches!(bytes[2], b'/' | b'\\');
-    let is_unc = if bytes.len() >= 5 && bytes[0] == b'\\' && bytes[1] == b'\\' {
+    let is_unc = if bytes.len() >= MIN_UNC_PATH_LENGTH && bytes[0] == b'\\' && bytes[1] == b'\\' {
         let third = bytes[2];
         third != b'\\' && third != b'/' && bytes[2..].contains(&b'\\')
     } else {
@@ -206,27 +213,24 @@ pub(crate) fn rustc_path_is_safe(rustc: &str) -> bool {
         return false;
     }
 
-    let (inspected_path, canonicalized) = match fs::canonicalize(path) {
-        Ok(path) => (path, true),
-        Err(_) if is_absolute_windows || is_unc => (PathBuf::from(rustc), false),
+    let (inspected_path, metadata) = match fs::canonicalize(path) {
+        Ok(canonical) => match metadata_for(&canonical) {
+            Some(meta) => (canonical, meta),
+            None => return false,
+        },
+        Err(_) if is_absolute_windows || is_unc => {
+            let fallback = PathBuf::from(rustc);
+            match metadata_for(&fallback).or_else(|| metadata_for(path)) {
+                Some(meta) => (fallback, meta),
+                None => return false,
+            }
+        },
         Err(_) => return false,
     };
 
     if has_suspicious_component(&inspected_path) {
         return false;
     }
-
-    let metadata = if canonicalized {
-        match metadata_for(&inspected_path) {
-            Some(meta) => meta,
-            None => return false,
-        }
-    } else {
-        match metadata_for(&inspected_path).or_else(|| metadata_for(path)) {
-            Some(meta) => meta,
-            None => return false,
-        }
-    };
 
     if !metadata.is_file() {
         return false;
@@ -236,28 +240,15 @@ pub(crate) fn rustc_path_is_safe(rustc: &str) -> bool {
     {
         use std::os::unix::fs::PermissionsExt;
 
-        const WORLD_WRITABLE: u32 = 0o002;
-        if metadata.permissions().mode() & WORLD_WRITABLE != 0 {
+        if metadata.permissions().mode() & WORLD_WRITABLE_MASK != 0 {
             return false;
         }
     }
 
     if let Some(parent) = inspected_path.parent() {
         let parent_lower = parent.to_string_lossy().to_ascii_lowercase();
-        const ALLOWED_PREFIXES: &[&str] = &[
-            "/usr/bin",
-            "/usr/local/bin",
-            "/opt/",
-            "c:/rust",
-            "c:/program files",
-            "c:/users",
-            "c\\rust",
-            "c\\program files",
-            "c\\users",
-        ];
-
         let allowed = parent_lower.starts_with("\\\\")
-            || ALLOWED_PREFIXES
+            || ALLOWED_PARENT_PREFIXES
                 .iter()
                 .any(|prefix| parent_lower.starts_with(prefix))
             || parent_lower.contains("/.cargo/bin")


### PR DESCRIPTION
## Summary
- Harden rustc path validation by canonicalizing candidate executables, rejecting encoded traversal attempts, constraining allowed wrappers, and extending tests (including a symlink regression case)
- Tighten header generation error handling and rebuild triggers by emitting specific rerun directives, surfacing cbindgen failures, and halting on empty or whitespace-only output
- Rely solely on pragma-once guards and improve write_if_changed diagnostics so permission errors surface instead of being silently masked

## Testing
- cargo fmt
- cargo test -p majestic-world-ffi

------
https://chatgpt.com/codex/tasks/task_e_68e1e3a7b550832289d8c947d0dc5d89